### PR TITLE
convert default value others to solo_stakers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This table stores the validators that are participating in the Rocketpool pool. 
 
 ### `t_identified_validators` (End result)
 
-This table stores the validators with the pool/entity that operates them. Unidentified validators will have a `f_pool_name` value of `others`. It has the following columns:
+This table stores the validators with the pool/entity that operates them. Unidentified validators, non-whales (see [Whale tagging](#whale-tagging)) will have a `f_pool_name` value of `solo_stakers`. It has the following columns:
 
 - `f_validator_pubkey`: The public key of the validator.
 - `f_pool_name`: The name of the pool in which the validators are participating.

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -5,7 +5,7 @@ import "github.com/pkg/errors"
 const (
 	addNewValidatorsQuery = `
 		INSERT INTO t_identified_validators (f_validator_pubkey, f_pool_name)
-		SELECT DISTINCT F_VALIDATOR_PUBKEY, 'others'::text
+		SELECT DISTINCT F_VALIDATOR_PUBKEY, 'solo_stakers'::text
 		FROM T_BEACON_DEPOSITS
 		WHERE F_VALIDATOR_PUBKEY != ''
 		ON CONFLICT (f_validator_pubkey) DO NOTHING;

--- a/db/migrations/000006_modify_defaul_pool_name.down.sql
+++ b/db/migrations/000006_modify_defaul_pool_name.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE t_identified_validators 
+ALTER COLUMN f_pool_name
+SET DEFAULT 'others';
+
+UPDATE t_identified_validators
+SET f_pool_name = 'others'
+WHERE f_pool_name = 'solo_stakers';

--- a/db/migrations/000006_modify_defaul_pool_name.up.sql
+++ b/db/migrations/000006_modify_defaul_pool_name.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE t_identified_validators 
+ALTER COLUMN f_pool_name
+SET DEFAULT 'solo_stakers';
+
+UPDATE t_identified_validators
+SET f_pool_name = 'solo_stakers'
+WHERE f_pool_name = 'others';


### PR DESCRIPTION
# Description

We are now tagging non-whale, unidentified validators as `solo_stakers`.
