### PR TITLE
Fix: New csm validators not tagged

### DIFF
--- a/lido/csm/contract.go
+++ b/lido/csm/contract.go
@@ -55,7 +55,7 @@ func (l *CSMContract) GetOperatorData(index *big.Int) (NodeOperatorCustom, error
 
 func (l *CSMContract) GetOperatorKeys(operator NodeOperatorCustom, startIndex uint64, keyCount uint64) ([][]byte, error) {
 	result, err := lido.RetryContractCall(func() (interface{}, error) {
-		return l.contract.GetSigningKeys(nil, big.NewInt(int64(operator.Index)), big.NewInt(0), big.NewInt(int64(keyCount)))
+		return l.contract.GetSigningKeys(nil, big.NewInt(int64(operator.Index)), big.NewInt(int64(startIndex)), big.NewInt(int64(keyCount)))
 	})
 	if err != nil {
 		return [][]byte{}, err


### PR DESCRIPTION
# Description
This pull request includes a key modification to the `GetOperatorKeys` function in the `lido/csm/contract.go` file. The change ensures that the `startIndex` parameter is correctly passed to the `GetSigningKeys` method, which fixes an issue where the function previously always started from index 0.

* [`lido/csm/contract.go`](diffhunk://#diff-16914759a02c28045708bb0cc53899d88c9ca717a1353243d3a1724a979127aaL58-R58): Modified the `GetOperatorKeys` function to pass the `startIndex` parameter to the `GetSigningKeys` method, ensuring the correct starting index is used.