### PR TITLE
Fix: depositors insert not applying

### DIFF
--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -4,20 +4,28 @@ import "github.com/pkg/errors"
 
 const (
 	applyDepositorsInsertQuery = `
-	INSERT INTO t_identified_validators (
-		f_validator_pubkey,
-		f_pool_name
-	)
-	SELECT DISTINCT 
-		t1.f_validator_pubkey, 
-		f_pool_name 
-	FROM 
-		t_beacon_deposits t1
-	RIGHT JOIN 
-		t_depositors_insert t2 
-	ON 
-		t1.f_depositor = t2.f_depositor
-	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name;
+		INSERT INTO t_identified_validators (
+			f_validator_pubkey,
+			f_pool_name
+		)
+		SELECT DISTINCT 
+			t1.f_validator_pubkey, 
+			t2.f_pool_name 
+		FROM (
+			SELECT 
+				f_validator_pubkey,
+				f_depositor,
+				ROW_NUMBER() OVER (
+					PARTITION BY f_validator_pubkey 
+					ORDER BY f_block_num DESC
+				) as rn
+			FROM t_beacon_deposits
+		) t1
+		INNER JOIN t_depositors_insert t2 
+			ON t1.f_depositor = t2.f_depositor
+		WHERE t1.rn = 1
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET 
+			f_pool_name = EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -30,7 +30,7 @@ func (p *PostgresDBService) ApplyDepositorsInsert() error {
 	}
 	defer conn.Release()
 
-	_, err = conn.Query(p.ctx, applyDepositorsInsertQuery)
+	_, err = conn.Exec(p.ctx, applyDepositorsInsertQuery)
 	if err != nil {
 		return errors.Wrap(err, "error applying validators insert")
 	}


### PR DESCRIPTION
This pull request fixes a bug caused by an edge case where a validator has 2 or more different depositors which have different tags on the depositors insert table. 

This results in error:
```
ERROR: ON CONFLICT DO UPDATE command cannot affect row a second time 
HINT: Ensure that no rows proposed for insertion within the same command have duplicate constrained values. SQL state: 21000
```

This error was not being catched by the script because the query was being ran with `conn.Query` which ignores errors. After changing it to `conn.Exec`, the error started breaking the script. 

To solve the bug, now `eth-pokhar` uses the latest depositor for tagging.