### PR TITLE
fix(identify): per-operator Lido reconcile, SDVT support, URL-safe tags

### DIFF
--- a/db/lido.go
+++ b/db/lido.go
@@ -31,6 +31,7 @@ const (
 	`
 	LidoProtocolCurated = "curated"
 	LidoProtocolCSM     = "csm"
+	LidoProtocolSDVT    = "sdvt"
 )
 
 // IdentifyLidoValidators identifies the lido validators and adds them to the identified validators table
@@ -75,6 +76,100 @@ func (p *PostgresDBService) ObtainLidoOperatorsValidatorCount(protocol string) (
 		operatorsValidatorCount = append(operatorsValidatorCount, count)
 	}
 	return operatorsValidatorCount, nil
+}
+
+// ReconcileLidoOperatorValidators makes t_lido reflect exactly the on-chain key
+// set for a given operator/protocol. It removes fossil keys (in DB but no longer
+// on-chain), inserts missing keys, and refreshes the operator name if it changed.
+// All work happens inside a single transaction so consumers never observe a
+// partially-rebuilt state for the operator.
+func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, operatorIndex uint64, onChainKeys []string, protocol string) (int64, int64, int64, error) {
+	p.writerThreadsWG.Add(1)
+	defer p.writerThreadsWG.Done()
+	startTime := time.Now()
+
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error acquiring database connection")
+	}
+	defer conn.Release()
+
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error beginning transaction")
+	}
+	defer tx.Rollback(p.ctx)
+
+	tempTableName := "tmp_lido_reconcile_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
+	_, err = tx.Exec(p.ctx, `
+		CREATE TEMP TABLE `+tempTableName+` (
+			f_validator_pubkey text PRIMARY KEY
+		) ON COMMIT DROP;
+	`)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error creating temp table")
+	}
+
+	if len(onChainKeys) > 0 {
+		rows := make([][]interface{}, len(onChainKeys))
+		for i, k := range onChainKeys {
+			rows[i] = []interface{}{k}
+		}
+		_, err = tx.CopyFrom(p.ctx, pgx.Identifier{tempTableName}, []string{"f_validator_pubkey"}, pgx.CopyFromRows(rows))
+		if err != nil {
+			return 0, 0, 0, errors.Wrap(err, "error copying on-chain keys into temp table")
+		}
+	}
+
+	delCmd, err := tx.Exec(p.ctx, `
+		DELETE FROM t_lido
+		WHERE f_operator_index = $1
+		  AND f_protocol = $2
+		  AND f_validator_pubkey NOT IN (SELECT f_validator_pubkey FROM `+tempTableName+`);
+	`, operatorIndex, protocol)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error deleting fossil keys")
+	}
+	removed := delCmd.RowsAffected()
+
+	insCmd, err := tx.Exec(p.ctx, `
+		INSERT INTO t_lido (f_validator_pubkey, f_operator, f_operator_index, f_protocol)
+		SELECT t.f_validator_pubkey, $1, $2, $3
+		FROM `+tempTableName+` t
+		ON CONFLICT (f_validator_pubkey) DO UPDATE
+			SET f_operator = EXCLUDED.f_operator,
+			    f_operator_index = EXCLUDED.f_operator_index,
+			    f_protocol = EXCLUDED.f_protocol
+		WHERE t_lido.f_operator       IS DISTINCT FROM EXCLUDED.f_operator
+		   OR t_lido.f_operator_index IS DISTINCT FROM EXCLUDED.f_operator_index
+		   OR t_lido.f_protocol       IS DISTINCT FROM EXCLUDED.f_protocol;
+	`, operator, operatorIndex, protocol)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error inserting fresh keys")
+	}
+	upserted := insCmd.RowsAffected()
+
+	renameCmd, err := tx.Exec(p.ctx, `
+		UPDATE t_lido
+		SET f_operator = $1
+		WHERE f_operator_index = $2
+		  AND f_protocol = $3
+		  AND f_operator <> $1;
+	`, operator, operatorIndex, protocol)
+	if err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error refreshing operator name")
+	}
+	renamed := renameCmd.RowsAffected()
+
+	if err := tx.Commit(p.ctx); err != nil {
+		return 0, 0, 0, errors.Wrap(err, "error committing reconcile transaction")
+	}
+
+	if upserted > 0 || removed > 0 || renamed > 0 {
+		wlog.Debugf("reconciled operator %v (proto=%v): upserted=%d removed=%d renamed=%d in %.2fs",
+			operator, protocol, upserted, removed, renamed, time.Since(startTime).Seconds())
+	}
+	return upserted, removed, renamed, nil
 }
 
 // CopyLidoOperatorValidators copies the validators to the database for a given operator

--- a/db/lido.go
+++ b/db/lido.go
@@ -80,23 +80,24 @@ func (p *PostgresDBService) ObtainLidoOperatorsValidatorCount(protocol string) (
 
 // ReconcileLidoOperatorValidators makes t_lido reflect exactly the on-chain key
 // set for a given operator/protocol. It removes fossil keys (in DB but no longer
-// on-chain), inserts missing keys, and refreshes the operator name if it changed.
-// All work happens inside a single transaction so consumers never observe a
-// partially-rebuilt state for the operator.
-func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, operatorIndex uint64, onChainKeys []string, protocol string) (int64, int64, int64, error) {
+// on-chain) and inserts missing keys; the UPSERT also refreshes f_operator,
+// f_operator_index and f_protocol for any row whose values diverged from
+// on-chain. All work happens inside a single transaction so consumers never
+// observe a partially-rebuilt state for the operator.
+func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, operatorIndex uint64, onChainKeys []string, protocol string) (int64, int64, error) {
 	p.writerThreadsWG.Add(1)
 	defer p.writerThreadsWG.Done()
 	startTime := time.Now()
 
 	conn, err := p.psqlPool.Acquire(p.ctx)
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error acquiring database connection")
+		return 0, 0, errors.Wrap(err, "error acquiring database connection")
 	}
 	defer conn.Release()
 
 	tx, err := conn.Begin(p.ctx)
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error beginning transaction")
+		return 0, 0, errors.Wrap(err, "error beginning transaction")
 	}
 	defer tx.Rollback(p.ctx)
 
@@ -107,7 +108,7 @@ func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, ope
 		) ON COMMIT DROP;
 	`)
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error creating temp table")
+		return 0, 0, errors.Wrap(err, "error creating temp table")
 	}
 
 	if len(onChainKeys) > 0 {
@@ -117,7 +118,7 @@ func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, ope
 		}
 		_, err = tx.CopyFrom(p.ctx, pgx.Identifier{tempTableName}, []string{"f_validator_pubkey"}, pgx.CopyFromRows(rows))
 		if err != nil {
-			return 0, 0, 0, errors.Wrap(err, "error copying on-chain keys into temp table")
+			return 0, 0, errors.Wrap(err, "error copying on-chain keys into temp table")
 		}
 	}
 
@@ -128,7 +129,7 @@ func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, ope
 		  AND f_validator_pubkey NOT IN (SELECT f_validator_pubkey FROM `+tempTableName+`);
 	`, operatorIndex, protocol)
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error deleting fossil keys")
+		return 0, 0, errors.Wrap(err, "error deleting fossil keys")
 	}
 	removed := delCmd.RowsAffected()
 
@@ -145,31 +146,19 @@ func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, ope
 		   OR t_lido.f_protocol       IS DISTINCT FROM EXCLUDED.f_protocol;
 	`, operator, operatorIndex, protocol)
 	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error inserting fresh keys")
+		return 0, 0, errors.Wrap(err, "error inserting fresh keys")
 	}
 	upserted := insCmd.RowsAffected()
 
-	renameCmd, err := tx.Exec(p.ctx, `
-		UPDATE t_lido
-		SET f_operator = $1
-		WHERE f_operator_index = $2
-		  AND f_protocol = $3
-		  AND f_operator <> $1;
-	`, operator, operatorIndex, protocol)
-	if err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error refreshing operator name")
-	}
-	renamed := renameCmd.RowsAffected()
-
 	if err := tx.Commit(p.ctx); err != nil {
-		return 0, 0, 0, errors.Wrap(err, "error committing reconcile transaction")
+		return 0, 0, errors.Wrap(err, "error committing reconcile transaction")
 	}
 
-	if upserted > 0 || removed > 0 || renamed > 0 {
-		wlog.Debugf("reconciled operator %v (proto=%v): upserted=%d removed=%d renamed=%d in %.2fs",
-			operator, protocol, upserted, removed, renamed, time.Since(startTime).Seconds())
+	if upserted > 0 || removed > 0 {
+		wlog.Debugf("reconciled operator %v (proto=%v): upserted=%d removed=%d in %.2fs",
+			operator, protocol, upserted, removed, time.Since(startTime).Seconds())
 	}
-	return upserted, removed, renamed, nil
+	return upserted, removed, nil
 }
 
 // CopyLidoOperatorValidators copies the validators to the database for a given operator

--- a/identify/lido.go
+++ b/identify/lido.go
@@ -66,12 +66,13 @@ func (i *Identify) identifySDVT() error {
 		if i.stop {
 			break
 		}
-		wg.Add(1)
-		workerSemaphore <- struct{}{}
 		operator, err := sdvtContract.GetOperatorData(big.NewInt(operatorIndex))
 		if err != nil {
+			wg.Wait()
 			return err
 		}
+		wg.Add(1)
+		workerSemaphore <- struct{}{}
 
 		go func(operator curated.NodeOperator) {
 			defer wg.Done()
@@ -126,11 +127,11 @@ func (i *Identify) processSDVTOperatorKeys(operator curated.NodeOperator) error 
 		offset += limit
 	}
 
-	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolSDVT)
+	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolSDVT)
 	if err != nil {
 		return err
 	}
-	log.Infof("SDVT operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
+	log.Infof("SDVT operator %v reconciled: on-chain=%d upserted=%d removed=%d", operatorName, totalKeys, upserted, removed)
 	return nil
 }
 
@@ -159,12 +160,13 @@ func (i *Identify) identifyCSM() error {
 		if i.stop {
 			break
 		}
-		wg.Add(1)
-		workerSemaphore <- struct{}{}
 		operator, err := csmContract.GetOperatorData(big.NewInt(operatorIndex))
 		if err != nil {
+			wg.Wait()
 			return err
 		}
+		wg.Add(1)
+		workerSemaphore <- struct{}{}
 
 		go func(operator csm.NodeOperatorCustom) {
 			defer wg.Done()
@@ -212,11 +214,11 @@ func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom) error
 		}
 	}
 
-	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
+	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
 	if err != nil {
 		return err
 	}
-	log.Infof("CSM operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
+	log.Infof("CSM operator %v reconciled: on-chain=%d upserted=%d removed=%d", operatorName, totalKeys, upserted, removed)
 	return nil
 }
 
@@ -247,12 +249,13 @@ func (i *Identify) identifyCuratedModule() error {
 		if i.stop {
 			break
 		}
-		wg.Add(1)
-		workerSemaphore <- struct{}{}
 		operator, err := lidoContract.GetOperatorData(big.NewInt(operatorIndex))
 		if err != nil {
+			wg.Wait()
 			return err
 		}
+		wg.Add(1)
+		workerSemaphore <- struct{}{}
 
 		go func(operator curated.NodeOperator) {
 			defer wg.Done()
@@ -311,10 +314,10 @@ func (i *Identify) processCuratedOperatorKeys(operator curated.NodeOperator) err
 		offset += limit
 	}
 
-	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)
+	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)
 	if err != nil {
 		return err
 	}
-	log.Infof("Curated operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
+	log.Infof("Curated operator %v reconciled: on-chain=%d upserted=%d removed=%d", operatorName, totalKeys, upserted, removed)
 	return nil
 }

--- a/identify/lido.go
+++ b/identify/lido.go
@@ -9,6 +9,7 @@ import (
 	"github.com/migalabs/eth-pokhar/lido"
 	"github.com/migalabs/eth-pokhar/lido/csm"
 	"github.com/migalabs/eth-pokhar/lido/curated"
+	"github.com/migalabs/eth-pokhar/lido/sdvt"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -22,6 +23,13 @@ func (i *Identify) IdentifyLidoValidators() error {
 	}
 	log.Debug("Identified lido curated module validators")
 
+	log.Debug("Identifying lido SDVT module validators")
+	err = i.identifySDVT()
+	if err != nil {
+		return err
+	}
+	log.Debug("Identified lido SDVT module validators")
+
 	log.Debug("Identifying lido csm validators")
 	err = i.identifyCSM()
 	if err != nil {
@@ -32,14 +40,103 @@ func (i *Identify) IdentifyLidoValidators() error {
 	return nil
 }
 
-///// CSM /////
+///// Simple DVT /////
 
-func (i *Identify) identifyCSM() error {
-	savedOperatorsValidatorsCount, err := i.dbClient.ObtainLidoOperatorsValidatorCount(db.LidoProtocolCSM)
+// identifySDVT identifies the validators for the Simple DVT module. Same key
+// registry semantics as the Curated module — only the contract address and
+// operator name resolution differ. Operator names come from the on-chain
+// contract (no pre-defined override list).
+func (i *Identify) identifySDVT() error {
+	log.Debug("Creating a new instance of SDVT contract")
+	sdvtContract, err := sdvt.NewSDVTContract(i.iConfig.ElEndpoint)
 	if err != nil {
 		return err
 	}
 
+	operatorsCount, err := sdvtContract.GetNodeOperatorsCount()
+	if err != nil {
+		return err
+	}
+	log.Debugf("Found %v SDVT operators", operatorsCount)
+
+	workerSemaphore := make(chan struct{}, 10)
+	var wg sync.WaitGroup
+
+	for operatorIndex := int64(0); operatorIndex < operatorsCount; operatorIndex++ {
+		if i.stop {
+			break
+		}
+		wg.Add(1)
+		workerSemaphore <- struct{}{}
+		operator, err := sdvtContract.GetOperatorData(big.NewInt(operatorIndex))
+		if err != nil {
+			return err
+		}
+
+		go func(operator curated.NodeOperator) {
+			defer wg.Done()
+			if err := i.processSDVTOperatorKeys(operator); err != nil {
+				log.Errorf("Error reconciling SDVT operator %v: %v", operator.Index, err)
+			}
+			<-workerSemaphore
+		}(operator)
+	}
+
+	wg.Wait()
+	if i.stop {
+		return nil
+	}
+
+	err = i.dbClient.IdentifyLidoValidators()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (i *Identify) processSDVTOperatorKeys(operator curated.NodeOperator) error {
+	sdvtContract, err := sdvt.NewSDVTContract(i.iConfig.ElEndpoint)
+	if err != nil {
+		return err
+	}
+
+	operatorName := sdvt.GetOperatorName(operator)
+	totalKeys := operator.TotalSigningKeys
+	log.Infof("Reconciling keys for SDVT operator %v (on-chain total=%v)", operatorName, totalKeys)
+
+	validatorPubkeys := make([]string, 0, totalKeys)
+	offset := uint64(0)
+	for offset < totalKeys {
+		if i.stop {
+			return nil
+		}
+		limit := totalKeys - offset
+		if limit > maxBatchSize {
+			limit = maxBatchSize
+		}
+
+		operatorKeys, err := sdvtContract.GetOperatorKeys(operator, offset, limit)
+		if err != nil {
+			return err
+		}
+		for k := uint64(0); k < limit; k++ {
+			key := operatorKeys.PubKeys[k*lido.PublicKeyLength : (k+1)*lido.PublicKeyLength]
+			validatorPubkeys = append(validatorPubkeys, hex.EncodeToString(key))
+		}
+		offset += limit
+	}
+
+	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolSDVT)
+	if err != nil {
+		return err
+	}
+	log.Infof("SDVT operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
+	return nil
+}
+
+///// CSM /////
+
+func (i *Identify) identifyCSM() error {
 	log.Debug("Creating a new instance of LidoContract")
 	csmContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
 	// Check if there was an error
@@ -69,18 +166,14 @@ func (i *Identify) identifyCSM() error {
 			return err
 		}
 
-		savedOperatorValidatorCount := uint64(0)
-		if operator.Index < uint64(len(savedOperatorsValidatorsCount)) {
-			savedOperatorValidatorCount = savedOperatorsValidatorsCount[operator.Index]
-		}
-		go func(operator csm.NodeOperatorCustom, savedOperatorValidatorCount uint64) {
+		go func(operator csm.NodeOperatorCustom) {
 			defer wg.Done()
-			err := i.processCSMOperatorKeys(operator, savedOperatorValidatorCount)
+			err := i.processCSMOperatorKeys(operator)
 			if err != nil {
 				log.Fatalf("Error processing operator keys: %v", err)
 			}
 			<-workerSemaphore
-		}(operator, savedOperatorValidatorCount)
+		}(operator)
 	}
 	log.Debug("Finished getting keys for each operator")
 
@@ -99,35 +192,31 @@ func (i *Identify) identifyCSM() error {
 	return nil
 }
 
-func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom, savedOperatorValidatorCount uint64) error {
-	savedOperatorValidatorCount32 := uint32(savedOperatorValidatorCount)
+func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom) error {
 	operatorName := csm.GetOperatorName(operator)
-	log.Infof("Getting new keys for operator %v", operatorName)
-	remainingKeys := operator.Operator.TotalDepositedKeys - savedOperatorValidatorCount32
-	if remainingKeys == 0 {
-		log.Infof("No new keys for operator %v", operatorName)
-		return nil
+	totalKeys := uint64(operator.Operator.TotalDepositedKeys)
+	log.Infof("Reconciling keys for CSM operator %v (on-chain total=%v)", operatorName, totalKeys)
+
+	keysString := make([]string, 0, totalKeys)
+	if totalKeys > 0 {
+		lidoContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
+		if err != nil {
+			return err
+		}
+		keys, err := lidoContract.GetOperatorKeys(operator, 0, totalKeys)
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			keysString = append(keysString, hex.EncodeToString(key))
+		}
 	}
 
-	log.Debug("Creating a new instance of LidoContract")
-	lidoContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
-	// Check if there was an error
+	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
 	if err != nil {
 		return err
 	}
-	log.Debug("Created a new instance of LidoContract")
-	keys, err := lidoContract.GetOperatorKeys(operator, uint64(savedOperatorValidatorCount32), uint64(remainingKeys))
-	if err != nil {
-		return err
-	}
-	keysString := make([]string, len(keys))
-	for i, key := range keys {
-		keysString[i] = hex.EncodeToString(key)
-	}
-	count := i.dbClient.CopyLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
-	log.Debugf("Inserted %v validators for operator %v", count, operatorName)
-	log.Infof("Got %v new keys for operator %v", remainingKeys, operatorName)
-
+	log.Infof("CSM operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
 	return nil
 }
 
@@ -135,12 +224,6 @@ func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom, saved
 
 // identifyCuratedModule identifies the validators for the curated module and adds them to the lido table
 func (i *Identify) identifyCuratedModule() error {
-
-	operatorsValidatorCount, err := i.dbClient.ObtainLidoOperatorsValidatorCount(db.LidoProtocolCurated)
-	if err != nil {
-		return err
-	}
-
 	log.Debug("Creating a new instance of LidoContract")
 	lidoContract, err := curated.NewCuratedModuleContract(i.iConfig.ElEndpoint)
 	// Check if there was an error
@@ -171,15 +254,13 @@ func (i *Identify) identifyCuratedModule() error {
 			return err
 		}
 
-		operatorValidatorCount := uint64(0)
-		if operator.Index < uint64(len(operatorsValidatorCount)) {
-			operatorValidatorCount = operatorsValidatorCount[operator.Index]
-		}
-		go func(operator curated.NodeOperator, operatorValidatorCount uint64) {
+		go func(operator curated.NodeOperator) {
 			defer wg.Done()
-			i.processCuratedOperatorKeys(operator, operatorValidatorCount)
+			if err := i.processCuratedOperatorKeys(operator); err != nil {
+				log.Errorf("Error reconciling curated operator %v: %v", operator.Index, err)
+			}
 			<-workerSemaphore
-		}(operator, operatorValidatorCount)
+		}(operator)
 	}
 	log.Debug("Finished getting keys for each operator")
 
@@ -198,53 +279,42 @@ func (i *Identify) identifyCuratedModule() error {
 	return nil
 }
 
-func (i *Identify) processCuratedOperatorKeys(operator curated.NodeOperator, operatorValidatorCount uint64) error {
-	log.Debug("Creating a new instance of LidoContract")
+func (i *Identify) processCuratedOperatorKeys(operator curated.NodeOperator) error {
 	lidoContract, err := curated.NewCuratedModuleContract(i.iConfig.ElEndpoint)
-	// Check if there was an error
 	if err != nil {
 		return err
 	}
-	log.Debug("Created a new instance of LidoContract")
 
 	operatorName := curated.GetOperatorName(operator)
-	log.Infof("Getting new keys for operator %v", operatorName)
-	remainingKeys := operator.TotalSigningKeys - operatorValidatorCount
-	if remainingKeys == 0 {
-		log.Infof("No new keys for operator %v", operatorName)
-		return nil
-	}
-	savedKeys := int64(0)
-	var validatorPubkeys []string
+	totalKeys := operator.TotalSigningKeys
+	log.Infof("Reconciling keys for curated operator %v (on-chain total=%v)", operatorName, totalKeys)
 
-	offset := operatorValidatorCount
-	for {
+	validatorPubkeys := make([]string, 0, totalKeys)
+	offset := uint64(0)
+	for offset < totalKeys {
 		if i.stop {
-			break
+			return nil
 		}
-		limit := min(remainingKeys-offset, maxBatchSize)
-		validatorPubkeys = make([]string, limit)
+		limit := totalKeys - offset
+		if limit > maxBatchSize {
+			limit = maxBatchSize
+		}
 
 		operatorKeys, err := lidoContract.GetOperatorKeys(operator, offset, limit)
 		if err != nil {
 			return err
 		}
-		for i := uint64(0); i < limit; i++ {
-			key := operatorKeys.PubKeys[i*lido.PublicKeyLength : (i+1)*lido.PublicKeyLength]
-			validatorPubkeys[i] = hex.EncodeToString(key)
-		}
-
-		log.Debugf("Inserting %v keys for operator %v into the database", limit, operatorName)
-		count := i.dbClient.CopyLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)
-		log.Debugf("Inserted %v validators for operator %v. %v remaining", count, operatorName, remainingKeys)
-		savedKeys += count
-		done := limit < maxBatchSize
-		if done {
-			break
+		for k := uint64(0); k < limit; k++ {
+			key := operatorKeys.PubKeys[k*lido.PublicKeyLength : (k+1)*lido.PublicKeyLength]
+			validatorPubkeys = append(validatorPubkeys, hex.EncodeToString(key))
 		}
 		offset += limit
 	}
-	log.Infof("Got %v new keys for operator %v", savedKeys, operatorName)
 
+	upserted, removed, renamed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)
+	if err != nil {
+		return err
+	}
+	log.Infof("Curated operator %v reconciled: on-chain=%d upserted=%d removed=%d renamed=%d", operatorName, totalKeys, upserted, removed, renamed)
 	return nil
 }

--- a/lido/common.go
+++ b/lido/common.go
@@ -28,7 +28,20 @@ func RetryContractCall(call func() (interface{}, error)) (interface{}, error) {
 		return result, nil
 	}
 }
+// FormatOperatorName normalizes a raw on-chain operator name into a URL-safe
+// pool tag. Spaces are dropped and ':' (used by SDVT cluster names like
+// "LidoxSSV: AgileAntelope") is replaced with '_' so frontends don't need to
+// URL-decode the tag. The "_lido" suffix is only appended when the name does
+// not already self-identify as Lido — SDVT operators start with "lidox..." so
+// the suffix would just be redundant. Operators whose normalized name does not
+// contain "lido" (e.g. future Curated additions) still get the suffix so
+// downstream consumers that filter on "%lido%" keep working.
 func FormatOperatorName(name string) string {
 	lower := strings.ToLower(name)
-	return strings.ReplaceAll(lower, " ", "") + "_lido"
+	lower = strings.ReplaceAll(lower, " ", "")
+	lower = strings.ReplaceAll(lower, ":", "_")
+	if strings.Contains(lower, "lido") {
+		return lower
+	}
+	return lower + "_lido"
 }

--- a/lido/sdvt/contract.go
+++ b/lido/sdvt/contract.go
@@ -1,0 +1,97 @@
+package sdvt
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/migalabs/eth-pokhar/lido"
+	"github.com/migalabs/eth-pokhar/lido/curated"
+)
+
+// Lido Simple DVT NodeOperatorsRegistry proxy on mainnet.
+// Shares the same ABI as the Curated module; only the address differs.
+const NODE_OPS_ADDRESS = "0xae7B191a31F627b4eB1d4DaC64eaB9976995b433"
+
+type SDVTContract struct {
+	contract *curated.NodeOperatorsRegistryCaller
+	address  string
+}
+
+func NewSDVTContract(nodeEndpoint string) (*SDVTContract, error) {
+	ethClient, err := ethclient.Dial(nodeEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer ethClient.Close()
+
+	contract, err := curated.NewNodeOperatorsRegistryCaller(common.HexToAddress(NODE_OPS_ADDRESS), ethClient)
+	if err != nil {
+		return nil, err
+	}
+	return &SDVTContract{contract: contract, address: NODE_OPS_ADDRESS}, nil
+}
+
+func (s *SDVTContract) GetNodeOperatorsCount() (int64, error) {
+	result, err := lido.RetryContractCall(func() (interface{}, error) {
+		return s.contract.GetNodeOperatorsCount(nil)
+	})
+	if err != nil {
+		return 0, err
+	}
+	return result.(*big.Int).Int64(), nil
+}
+
+func (s *SDVTContract) GetOperatorData(index *big.Int) (curated.NodeOperator, error) {
+	result, err := lido.RetryContractCall(func() (interface{}, error) {
+		return s.contract.GetNodeOperator(nil, index, true)
+	})
+	if err != nil {
+		return curated.NodeOperator{}, err
+	}
+	operator := result.(struct {
+		Active            bool
+		Name              string
+		RewardAddress     common.Address
+		StakingLimit      uint64
+		StoppedValidators uint64
+		TotalSigningKeys  uint64
+		UsedSigningKeys   uint64
+	})
+	return curated.NodeOperator{
+		Index:             index.Uint64(),
+		Active:            operator.Active,
+		Name:              operator.Name,
+		RewardAddress:     operator.RewardAddress,
+		StakingLimit:      operator.StakingLimit,
+		StoppedValidators: operator.StoppedValidators,
+		TotalSigningKeys:  operator.TotalSigningKeys,
+		UsedSigningKeys:   operator.UsedSigningKeys,
+	}, nil
+}
+
+func (s *SDVTContract) GetOperatorKeys(operator curated.NodeOperator, offset uint64, limit uint64) (curated.OperatorKeys, error) {
+	result, err := lido.RetryContractCall(func() (interface{}, error) {
+		return s.contract.GetSigningKeys(nil, big.NewInt(int64(operator.Index)), big.NewInt(int64(offset)), big.NewInt(int64(limit)))
+	})
+	if err != nil {
+		return curated.OperatorKeys{}, err
+	}
+	operatorKeys := result.(struct {
+		Pubkeys    []byte
+		Signatures []byte
+		Used       []bool
+	})
+	return curated.OperatorKeys{
+		PubKeys:    operatorKeys.Pubkeys,
+		Signatures: operatorKeys.Signatures,
+		Used:       operatorKeys.Used,
+	}, nil
+}
+
+// GetOperatorName returns the tag for an SDVT operator. Unlike Curated, SDVT
+// has no canonical pre-defined operator-name list — names come straight from
+// the on-chain contract and are normalized through lido.FormatOperatorName.
+func GetOperatorName(operator curated.NodeOperator) string {
+	return lido.FormatOperatorName(operator.Name)
+}


### PR DESCRIPTION
## Summary

Two related fixes, both already verified in production on `crawler` for several days. PR opened now to close the loop upstream.

### 1. Per-operator reconcile in t_lido (commit f58bbe7)

`identifyCuratedModule` and `processCSMOperatorKeys` previously decided what to fetch via `remainingKeys = TotalSigningKeys - savedCount` and inserted with `ON CONFLICT DO NOTHING`. Lido operators can rotate keys (`removeSigningKeys`, `invalidateReadyToDepositKeysRange`), which shifts on-chain indices without growing the count — so the count-diff path skipped resync and left stale pubkeys at slots that on-chain held different keys. Affected validators fell through to the generic `lido` fallback from `t_depositors_insert`.

Replaced with a transactional reconcile per operator:

  * fetch the full on-chain key set (offset 0, limit = TotalSigningKeys) in batched calls;
  * `ReconcileLidoOperatorValidators` in a single tx: DELETEs fossil keys for the (operator_index, protocol) tuple, UPSERTs the current set, refreshes the operator name when it changed;
  * per-operator logs report on-chain / upserted / removed / renamed counts.

Also adds a third Lido staking module to the scan: **SimpleDVT** (proxy `0xae7B191a31F627b4eB1d4DaC64eaB9976995b433`, new `f_protocol = 'sdvt'`). The contract shares the NodeOperatorsRegistry ABI with Curated; SDVT cluster names come straight from the on-chain contract and are normalised through `lido.FormatOperatorName`. Without this the ~16k SDVT validators deposited via the Lido StakingRouter were unresolvable and stayed tagged as the generic `lido`.

### 2. URL-safe operator tags + drop redundant `_lido` suffix (commit 17a092a)

SDVT cluster names from the on-chain registry contain `:` (e.g. `LidoxSSV: AgileAntelope`), which got URL-encoded to `%3A` by downstream consumers and rendered verbatim in entity pages. `FormatOperatorName` now replaces `:` with `_` and stops appending the `_lido` suffix when the normalised name already self-identifies as Lido (every SDVT name starts with `lidoxobol` / `lidoxssv` — the suffix was redundant). Operators whose name does not contain `lido` still get the suffix, so any downstream filter on `%lido%` keeps working.

## Production state (already running this branch)

  * Pre-fix: 14,605 Lido validators tagged generic `lido` (Launchnodes case Sabrina reported).
  * Post-fix: 0 generic `lido`; ~497k validators correctly attributed across Curated, SDVT and CSM.
  * Container is currently on `17a092a`; cron at 02:00 UTC runs the image built from this branch.
  * ClickHouse sync on att-2 / eth-archive / att-6 already reflects the new tags.

## Test plan

  * [x] Local smoke against  EL + restored postgres dump → 100% match on Launchnodes/Sabrina case.
  * [x] Production identify run completed in 53m on `crawler` with `--recreate-table`.
  * [x] DB verification on prod: validator 1,453,657 → `launchnodes_lido`, generic `lido` count = 0, t_lido protocol counts match on-chain totals.
  * [x] URL-safe retag applied via direct SQL on prod + re-sync to all three downstream ClickHouse instances.

## Follow-up

  * CM v2 support (`feat/cm-v2-support`) will be opened separately and rebased on top of this branch once merged.