### PR TITLE
chore(github): activate issue and PR templates on main

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,101 @@
+name: Bug Report
+description: Report something that is broken or not behaving as expected
+title: "[bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of the bug.
+      placeholder: "`identify` exits with a panic while processing Lido CSM operators..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps to reproduce the behavior, including the command and relevant flags.
+      placeholder: |
+        1. Sync the database with `eth-pokhar beacon_depositors_transactions ...`
+        2. Run `eth-pokhar identify --log-level=debug ...`
+        3. Wait for the Lido identification step
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: |
+        Critical = crash, data corruption or wrong tagging results. High = major feature broken, no workaround.
+        Medium = feature impaired, workaround exists. Low = minor or cosmetic.
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which module/component is affected? Pick the closest match.
+      options:
+        - identify
+        - lido
+        - rocketpool
+        - coinbase
+        - beacon-deposits
+        - db
+        - alchemy
+        - config
+        - docker/ci
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: command
+    attributes:
+      label: Command affected
+      options:
+        - identify
+        - beacon_depositors_transactions
+        - both / not command-specific
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in what applies.
+      value: |
+        - eth-pokhar version/commit:
+        - Go version:
+        - Network: mainnet
+        - EL endpoint type (local node / Infura / Alchemy / ...):
+        - PostgreSQL (version, docker-compose or external):
+        - OS:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Paste relevant log output. Redact API keys and private endpoints. This is automatically formatted, no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or an improvement to existing behavior
+title: "[feat]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve? Why is it needed?
+      placeholder: "Re-fetching transactions for already tagged addresses wastes Alchemy quota and slows down syncs..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe how you would like it to work. Include CLI flags, config options or new entities/pools if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you considered and why they fall short.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which module/component would this touch? Pick the closest match.
+      options:
+        - identify
+        - lido
+        - rocketpool
+        - coinbase
+        - beacon-deposits
+        - db
+        - alchemy
+        - config
+        - docker/ci
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this to you?
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-performance.yml
+++ b/.github/ISSUE_TEMPLATE/3-performance.yml
@@ -27,7 +27,7 @@ body:
   - type: dropdown
     id: severity
     attributes:
-      label: Impact
+      label: Severity
       description: |
         Critical = makes the tool unusable or exhausts quotas. High = major slowdown on every run.
         Medium = noticeable but tolerable. Low = minor optimization opportunity.

--- a/.github/ISSUE_TEMPLATE/3-performance.yml
+++ b/.github/ISSUE_TEMPLATE/3-performance.yml
@@ -1,0 +1,69 @@
+name: Performance Issue
+description: Report slowness, excessive resource usage or API quota problems
+title: "[perf]: "
+labels: ["performance", "needs-triage"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What is slow or consuming too many resources (time, memory, DB size, RPC/Alchemy requests)?
+      placeholder: "The Lido curated module routine takes ~6h on a synced database, most of it in per-key contract calls..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Measurements / baseline
+      description: Numbers that show the problem — durations, request counts, DB sizes. The README benchmark tables are a good reference point.
+      placeholder: |
+        - identify (full run): 5h 58m
+        - Alchemy requests: ~1.2M
+        - Database size after sync: 3.4 GB
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Impact
+      description: |
+        Critical = makes the tool unusable or exhausts quotas. High = major slowdown on every run.
+        Medium = noticeable but tolerable. Low = minor optimization opportunity.
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which module/component is affected? Pick the closest match.
+      options:
+        - identify
+        - lido
+        - rocketpool
+        - coinbase
+        - beacon-deposits
+        - db
+        - alchemy
+        - config
+        - docker/ci
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - eth-pokhar version/commit:
+        - EL endpoint type (local node / Infura / Alchemy / ...):
+        - Hardware (CPU / RAM / disk):

--- a/.github/ISSUE_TEMPLATE/4-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation.yml
@@ -1,0 +1,27 @@
+name: Documentation
+description: Report missing, wrong or unclear documentation
+title: "[docs]: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where is the documentation problem? File, section or link.
+      placeholder: "README.md — 'Run the tool' section"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing?
+      description: Describe the gap, error or ambiguity.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: If you have an idea of what it should say instead, write it here.

--- a/.github/ISSUE_TEMPLATE/5-task.yml
+++ b/.github/ISSUE_TEMPLATE/5-task.yml
@@ -1,0 +1,57 @@
+name: Task / Chore
+description: Refactors, tech debt, dependency updates, tooling and other maintenance work
+title: "[task]: "
+labels: ["chore", "needs-triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why.
+      placeholder: "Bump go-ethereum to the latest release and adapt to the new bind API..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: task-type
+    attributes:
+      label: Task type
+      options:
+        - Refactor / tech debt
+        - Dependency update
+        - Tooling / CI
+        - Testing
+        - Other maintenance
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which module/component does this touch? Pick the closest match.
+      options:
+        - identify
+        - lido
+        - rocketpool
+        - coinbase
+        - beacon-deposits
+        - db
+        - alchemy
+        - config
+        - docker/ci
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!-- PR title must follow Conventional Commits with a scope, e.g. `fix(lido/cmv2): validate endpoint addresses` -->
+
+## Description
+
+<!-- What does this PR do and why? 1-3 sentences. -->
+
+## Related issue
+
+<!-- e.g. Closes #17 — remove if none -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor (no functional change)
+- [ ] Performance improvement
+- [ ] Documentation
+- [ ] Chore / maintenance
+
+## Affected area(s)
+
+<!-- e.g. identify, lido, rocketpool, coinbase, beacon-deposits, db, alchemy, config, docker/ci, docs -->
+
+## How was this tested?
+
+<!-- Commands run and context: network, EL endpoint type, database state (fresh vs synced). -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) with a scope
+- [ ] Database schema changes include a migration in `db/migrations`
+- [ ] README updated if CLI flags, commands or setup steps changed
+- [ ] No secrets, API keys or private endpoints committed
+- [ ] `go build ./...` and `go vet ./...` pass locally

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 <!-- PR title must follow Conventional Commits with a scope, e.g. `fix(lido/cmv2): validate endpoint addresses` -->
+<!-- Target branch must be `dev`. `main` (production) only accepts release PRs from `dev` or `hotfix/*` branches. -->
 
 ## Description
 

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,72 @@
+policy:
+  - template: ['1-bug-report.yml', '3-performance.yml']
+    section:
+      - id: ['severity']
+        block-list: []
+        label:
+          - name: 'severity:critical'
+            keys: ['Critical']
+          - name: 'severity:high'
+            keys: ['High']
+          - name: 'severity:medium'
+            keys: ['Medium']
+          - name: 'severity:low'
+            keys: ['Low']
+      - id: ['area']
+        block-list: ['other']
+        label:
+          - name: 'area:identify'
+            keys: ['identify']
+          - name: 'area:lido'
+            keys: ['lido']
+          - name: 'area:rocketpool'
+            keys: ['rocketpool']
+          - name: 'area:coinbase'
+            keys: ['coinbase']
+          - name: 'area:beacon-deposits'
+            keys: ['beacon-deposits']
+          - name: 'area:db'
+            keys: ['db']
+          - name: 'area:alchemy'
+            keys: ['alchemy']
+          - name: 'area:config'
+            keys: ['config']
+          - name: 'area:ci'
+            keys: ['docker/ci']
+          - name: 'area:docs'
+            keys: ['docs']
+
+  - template: ['2-feature-request.yml', '5-task.yml']
+    section:
+      - id: ['priority']
+        block-list: []
+        label:
+          - name: 'priority:high'
+            keys: ['High']
+          - name: 'priority:medium'
+            keys: ['Medium']
+          - name: 'priority:low'
+            keys: ['Low']
+      - id: ['area']
+        block-list: ['other']
+        label:
+          - name: 'area:identify'
+            keys: ['identify']
+          - name: 'area:lido'
+            keys: ['lido']
+          - name: 'area:rocketpool'
+            keys: ['rocketpool']
+          - name: 'area:coinbase'
+            keys: ['coinbase']
+          - name: 'area:beacon-deposits'
+            keys: ['beacon-deposits']
+          - name: 'area:db'
+            keys: ['db']
+          - name: 'area:alchemy'
+            keys: ['alchemy']
+          - name: 'area:config'
+            keys: ['config']
+          - name: 'area:ci'
+            keys: ['docker/ci']
+          - name: 'area:docs'
+            keys: ['docs']

--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -1,0 +1,19 @@
+name: Enforce PR target
+
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only dev and hotfix branches may target main
+        if: github.head_ref != 'dev' && !startsWith(github.head_ref, 'hotfix/')
+        run: |
+          echo "::error::main only accepts PRs from 'dev' or 'hotfix/*'. Retarget this PR to 'dev' (gh pr edit ${{ github.event.pull_request.number }} --base dev)."
+          exit 1

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -13,26 +13,31 @@ jobs:
     permissions:
       contents: read
       issues: write
-    strategy:
-      fail-fast: false
-      matrix:
-        template:
-          - 1-bug-report.yml
-          - 2-feature-request.yml
-          - 3-performance.yml
-          - 5-task.yml
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve source template from the form marker label
+        id: template
+        env:
+          TEMPLATE: >-
+            ${{ (contains(github.event.issue.labels.*.name, 'bug') && '1-bug-report.yml')
+             || (contains(github.event.issue.labels.*.name, 'enhancement') && '2-feature-request.yml')
+             || (contains(github.event.issue.labels.*.name, 'performance') && '3-performance.yml')
+             || (contains(github.event.issue.labels.*.name, 'chore') && '5-task.yml')
+             || '' }}
+        run: echo "file=$TEMPLATE" >> "$GITHUB_OUTPUT"
+
       - name: Parse issue form
         id: issue-parser
+        if: steps.template.outputs.file != ''
         uses: stefanbuck/github-issue-parser@v3
         with:
-          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+          template-path: .github/ISSUE_TEMPLATE/${{ steps.template.outputs.file }}
 
       - name: Apply labels from form dropdowns
+        if: steps.template.outputs.file != ''
         uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
         with:
           issue-form: ${{ steps.issue-parser.outputs.jsonString }}
-          template: ${{ matrix.template }}
+          template: ${{ steps.template.outputs.file }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,38 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - 1-bug-report.yml
+          - 2-feature-request.yml
+          - 3-performance.yml
+          - 5-task.yml
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse issue form
+        id: issue-parser
+        uses: stefanbuck/github-issue-parser@v3
+        with:
+          template-path: .github/ISSUE_TEMPLATE/${{ matrix.template }}
+
+      - name: Apply labels from form dropdowns
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          template: ${{ matrix.template }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Brings the GitHub templates from dev into main so they take effect.

GitHub only reads issue forms, the PR template and the issue/PR workflows from the default branch (main), so they stay dormant until merged here.

Contents (config only, no code changes):
- 5 issue forms: bug, feature, performance, documentation, task
- single PR template
- auto-labeler workflow that maps the form dropdowns to severity, priority and area labels
- workflow that keeps main as a release-only branch (PRs from dev or hotfix/*)

After merge, opening a new issue shows the forms and blank issues are disabled.