### PR TITLE
fix(identify): owner tags win over operator tags (withdrawal after depositors)

### DIFF
--- a/identify/identify.go
+++ b/identify/identify.go
@@ -105,18 +105,12 @@ func (i *Identify) Run() {
 		}
 	}
 
-	if !i.stop {
-		startTime := time.Now()
-		log.Info("Applying withdrawal address insert")
-		err := i.dbClient.ApplyWithdrawalAddressInsert()
-		if err != nil {
-			log.Errorf("Error applying withdrawal address insert: %v. Skipping to next step.", err)
-		} else {
-			endTime := time.Now()
-			log.Infof("Applied withdrawal address insert in %v", endTime.Sub(startTime))
-		}
-	}
-
+	// Depositor tags (typically the node operator) are applied BEFORE
+	// withdrawal-address tags (the owner of the stake) on purpose: both
+	// upserts resolve conflicts positionally (last write wins), and a
+	// withdrawal credential is a stronger ownership signal than who sent
+	// the deposit transaction, since batch-deposit contracts are shared
+	// infrastructure. See issue #28.
 	if !i.stop {
 		startTime := time.Now()
 		log.Info("Applying depositors insert")
@@ -126,6 +120,18 @@ func (i *Identify) Run() {
 		} else {
 			endTime := time.Now()
 			log.Infof("Applied depositors insert in %v", endTime.Sub(startTime))
+		}
+	}
+
+	if !i.stop {
+		startTime := time.Now()
+		log.Info("Applying withdrawal address insert")
+		err := i.dbClient.ApplyWithdrawalAddressInsert()
+		if err != nil {
+			log.Errorf("Error applying withdrawal address insert: %v. Skipping to next step.", err)
+		} else {
+			endTime := time.Now()
+			log.Infof("Applied withdrawal address insert in %v", endTime.Sub(startTime))
 		}
 	}
 


### PR DESCRIPTION
Minimal fix for the precedence bug described in #28: `ApplyDepositorsInsert` and `ApplyWithdrawalAddressInsert` swap positions, so owner tags (withdrawal credentials) now win over operator tags (deposit senders). Manual pins via `t_validators_insert` keep running last and still override everything.

Resulting precedence: `validators_insert > lido > rocketpool > coinbase > withdrawal > depositors > whales`.

## Deploy note (data fix required)

As documented in the verification note of #28, the `figment` row attached to the Coinbase client withdrawal address `0x2324b024...` in `t_withdrawal_address_insert` is an operator label sitting on an owner address. With this swap it would win over the correct `coinbase` depositor tag for those 34 validators, so that row should be removed from the insert table before (or when) this lands.

## Scope

This fixes the daily regeneration of the mislabeling with the smallest possible change. The custody/operation two-dimension model proposed in #28 remains open as the structural follow-up. Once deployed, the corrected tags will propagate into recent pool summaries automatically on consumers running the refresh from migalabs/goteth#278.
