### PR TITLE
feat(beacon-depositors-transactions): skip transfers fetch for strongly tagged depositors

### DIFF
--- a/beacon-depositors-transactions/routines.go
+++ b/beacon-depositors-transactions/routines.go
@@ -17,11 +17,15 @@ import (
 
 func (b *BeaconDepositorsTransactions) updateDepositorsTransactions() {
 	log.Info("Getting checkpoints")
-	checkpoints, err := b.dbClient.ObtainCheckpointPerDepositor()
+	checkpoints, err := b.dbClient.ObtainCheckpointPerDepositor(b.iConfig.SkipTagged)
 	if err != nil {
 		log.Fatalf("Error obtaining checkpoints: %s", err.Error())
 	}
-	log.Info("Got checkpoints")
+	if b.iConfig.SkipTagged {
+		log.Infof("Got checkpoints for %d depositors with untagged validators (skip-tagged enabled)", len(checkpoints))
+	} else {
+		log.Infof("Got checkpoints for %d depositors", len(checkpoints))
+	}
 
 	log.Info("Fetching new transactions")
 

--- a/cmd/beacon-depositors-transactions/cmd.go
+++ b/cmd/beacon-depositors-transactions/cmd.go
@@ -53,6 +53,11 @@ var BeaconDepositorsTransactionsCommand = &cli.Command{
 			Name:  "only-deposits",
 			Usage: "Only fetch deposits. If not set, it will fetch all new depositor transactions which can take up to 20 hours",
 		},
+		&cli.BoolFlag{
+			Name:    "skip-tagged",
+			Usage:   "Skip fetching transactions for depositors whose validators are all already identified. Transactions are only used to identify coinbase validators, so this saves most Alchemy credits/node calls and runtime; a new deposit brings its depositor back into scope automatically",
+			EnvVars: []string{"SKIP_TAGGED"},
+		},
 	},
 }
 

--- a/config/beacon_depositors_transactions_config.go
+++ b/config/beacon_depositors_transactions_config.go
@@ -11,6 +11,7 @@ type BeaconDepositorsTransactionsConfig struct {
 	Workers      int    `json:"workers-num"`
 	AlchemyURL   string `json:"alchemy-url"`
 	OnlyDeposits bool   `json:"only-deposits"`
+	SkipTagged   bool   `json:"skip-tagged"`
 }
 
 func NewBeaconDepositorsTransactionsConfig() *BeaconDepositorsTransactionsConfig {
@@ -46,6 +47,10 @@ func (c *BeaconDepositorsTransactionsConfig) Apply(ctx *cli.Context) {
 
 	if ctx.IsSet("only-deposits") {
 		c.OnlyDeposits = true
+	}
+
+	if ctx.IsSet("skip-tagged") {
+		c.SkipTagged = true
 	}
 
 }

--- a/db/beacon_depositors_transactions.go
+++ b/db/beacon_depositors_transactions.go
@@ -23,23 +23,54 @@ var (
 		select f_depositor, MAX(f_block_num) f_max_block_num
 		from t_beacon_depositors_transactions
 		group by f_depositor)
-	
+
 	SELECT d.f_depositor, COALESCE(MAX(t.f_max_block_num), 0) f_max_block_num
 		FROM t_beacon_deposits d
 		LEFT JOIN max_block_per_depositor t ON d.f_depositor = t.f_depositor
 		GROUP BY d.f_depositor
 		ORDER BY f_max_block_num ASC;
 	`
+
+	// Same as above, but only depositors with at least one validator whose
+	// tag is weak: missing, empty, whale_* or solo_stakers. Transactions are
+	// only used to identify coinbase validators, and coinbase candidates are
+	// precisely the validators that would otherwise sit in those catch-all
+	// buckets, so depositors whose validators all carry a strong tag do not
+	// need their transfer history refreshed. Every validator gets a row in
+	// t_identified_validators on each identify run, so row existence alone
+	// cannot be used as the filter (see issue #17).
+	selectCheckpointPerUntaggedDepositor = `
+	WITH max_block_per_depositor AS (
+		select f_depositor, MAX(f_block_num) f_max_block_num
+		from t_beacon_depositors_transactions
+		group by f_depositor)
+
+	SELECT d.f_depositor, COALESCE(MAX(t.f_max_block_num), 0) f_max_block_num
+		FROM t_beacon_deposits d
+		LEFT JOIN max_block_per_depositor t ON d.f_depositor = t.f_depositor
+		LEFT JOIN t_identified_validators iv ON iv.f_validator_pubkey = d.f_validator_pubkey
+		GROUP BY d.f_depositor
+		HAVING COUNT(*) FILTER (WHERE iv.f_validator_pubkey IS NULL
+			OR iv.f_pool_name IS NULL
+			OR iv.f_pool_name = ''
+			OR iv.f_pool_name LIKE 'whale\_%'
+			OR iv.f_pool_name = 'solo_stakers') > 0
+		ORDER BY f_max_block_num ASC;
+	`
 )
 
-func (p *PostgresDBService) ObtainCheckpointPerDepositor() ([]models.DepositorCheckpoint, error) {
+func (p *PostgresDBService) ObtainCheckpointPerDepositor(skipTagged bool) ([]models.DepositorCheckpoint, error) {
 	conn, err := p.psqlPool.Acquire(p.ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error acquiring database connection")
 	}
 	defer conn.Release()
 
-	rows, err := conn.Query(p.ctx, selectCheckpointPerDepositor)
+	query := selectCheckpointPerDepositor
+	if skipTagged {
+		query = selectCheckpointPerUntaggedDepositor
+	}
+	rows, err := conn.Query(p.ctx, query)
 	if err != nil {
 		rows.Close()
 		return nil, err


### PR DESCRIPTION
Implements #17 with one adjustment discovered while measuring on the production labels database.

## What it does

New `--skip-tagged` flag (env `SKIP_TAGGED`) for `beacon_depositors_transactions`: the transfers fetch only processes depositors that still have at least one **weakly tagged** validator: missing from `t_identified_validators`, empty pool name, `whale_*` or `solo_stakers`. Those are exactly the coinbase candidate pool, which is the only consumer of the fetched transactions.

## Why "weakly tagged" instead of "untagged"

The issue proposes skipping depositors whose validators are already tagged, but every validator gets a row in `t_identified_validators` on each identify run (whales and catch-all phases tag everyone), so row existence filters out everything: measured on production, only 1 depositor out of 301,222 would qualify. Filtering by tag strength keeps the intent while staying correct for coinbase detection: validators that could still be reclassified as coinbase are precisely the ones sitting in the catch-all buckets.

## Measured impact

On the production labels database today: 119,130 of 301,222 depositors (39.5%) have at least one weakly tagged validator, so a full transfers run and its Alchemy credit usage drop by ~60%. Depositors making new deposits re-enter scope automatically (new validators are weakly tagged until identified).

Note: this does not change the daily identify runtime (the daily cron already runs with `ONLY_DEPOSITS=true`); it targets the full transfers runs and the API cost. The daily 2h runtime is dominated by the identify SQL and Lido on-chain phases, tracked separately.

Off by default, opt-in flag. Refs #17
