### PR TITLE
feat(scripts): optional t_pubkey_pool mirror in the labels sync

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ Distributes the labels produced by the identify pipeline (Postgres `t_identified
 - **Versioned**: each applied snapshot inserts a row into `t_eth2_pubkeys_version` (query with `FINAL`, it keeps the highest `f_version`). Consumers such as the goteth pool summary reroll can log exactly which labels version they operate on.
 - **Gated**: the snapshot is rejected, keeping the previous mapping, if it is empty, if it shrinks below `SYNC_MIN_COUNT_RATIO` of the previous count, or if any existing pool loses more than `SYNC_MAX_POOL_DROP` validators. Legitimate renames or splits are declared in the allowlist file (`SYNC_POOL_RENAME_ALLOWLIST`, one pool name per line) for the run where they happen.
 - **Monitored**: with `TEXTFILE_DIR` set, exports `cron_job_last_run_timestamp_seconds`, `cron_job_last_run_time_taken_milliseconds` and `cron_job_last_run_exit_status` for node_exporter's textfile collector.
+- **Optional mirror**: with `SYNC_PUBKEY_POOL=true`, also refreshes the `t_pubkey_pool` mirror (pubkey to pool without a val_idx, used to label deposits still in the pending queue) with the same staging plus `EXCHANGE TABLES` pattern. Enable it only on deployments that have that table.
 
 ### Example
 

--- a/scripts/sync-labels-to-clickhouse.sh
+++ b/scripts/sync-labels-to-clickhouse.sh
@@ -157,6 +157,31 @@ fi
 echo "$LOG_PREFIX Gates passed. Applying snapshot atomically..."
 ch "EXCHANGE TABLES t_eth2_pubkeys AND t_eth2_pubkeys_staging" || exit 1
 
+# ------------------------------------------------- optional t_pubkey_pool mirror
+# Some deployments also serve a pubkey -> pool mirror without requiring a
+# val_idx assignment (labels for deposits still in the pending queue). Same
+# staging + EXCHANGE pattern; the source snapshot already passed the gates.
+if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
+    echo "$LOG_PREFIX Syncing t_pubkey_pool mirror..."
+    ch "CREATE TABLE IF NOT EXISTS t_pubkey_pool_staging AS t_pubkey_pool" || exit 1
+    ch "TRUNCATE TABLE t_pubkey_pool_staging" || exit 1
+    ch "
+        INSERT INTO t_pubkey_pool_staging (f_public_key, f_pool_name)
+        SELECT
+            concat('0x', iv.f_validator_pubkey) AS f_public_key,
+            iv.f_pool_name
+        FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
+    " || { echo "$LOG_PREFIX ERROR: t_pubkey_pool import failed, live mirror untouched"; exit 1; }
+    PP_COUNT=$(ch "SELECT count() FROM t_pubkey_pool_staging") || exit 1
+    if [ "$PP_COUNT" -eq 0 ]; then
+        echo "$LOG_PREFIX GATE FAILED: t_pubkey_pool snapshot is empty, live mirror untouched"
+        exit 1
+    fi
+    ch "EXCHANGE TABLES t_pubkey_pool AND t_pubkey_pool_staging" || exit 1
+    echo "$LOG_PREFIX t_pubkey_pool updated: $PP_COUNT entries"
+fi
+
+# ------------------------------------------------- version stamp
 VERSION=$(date +%s)
 ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_version (
         f_version UInt64,


### PR DESCRIPTION
Follow-up to #32, needed to fully replace the legacy sync on deployments that also maintain the `t_pubkey_pool` mirror (pubkey to pool without val_idx, used to label deposits still in the pending queue). Opt-in via `SYNC_PUBKEY_POOL=true`, same staging plus EXCHANGE TABLES pattern, applied only after the main snapshot passed the sanity gates. Refs #31