### PR TITLE
feat(identify): incremental daily runs (env-driven recreate, write guards, deposit indexes)

### DIFF
--- a/db/coinbase.go
+++ b/db/coinbase.go
@@ -54,6 +54,7 @@ const (
 				'd2276af80582cac230edc4c42e9a9c096f3c09aa')
 		)
 	)
+	AND f_pool_name IS DISTINCT FROM 'coinbase'
 	`
 )
 

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -24,8 +24,9 @@ const (
 		INNER JOIN t_depositors_insert t2 
 			ON t1.f_depositor = t2.f_depositor
 		WHERE t1.rn = 1
-		ON CONFLICT (f_validator_pubkey) DO UPDATE SET 
-			f_pool_name = EXCLUDED.f_pool_name;
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_pool_name = EXCLUDED.f_pool_name
+		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -57,7 +57,14 @@ const (
 				F_VALIDATOR_PUBKEY != ''
 		) AS subquery2
 		WHERE 
-			t_identified_validators.f_validator_pubkey = subquery2.f_validator_pubkey;
+			t_identified_validators.f_validator_pubkey = subquery2.f_validator_pubkey
+			AND t_identified_validators.f_pool_name IS DISTINCT FROM subquery2.whale_id
+			AND (
+				t_identified_validators.f_pool_name IS NULL
+				OR t_identified_validators.f_pool_name = ''
+				OR t_identified_validators.f_pool_name = 'solo_stakers'
+				OR t_identified_validators.f_pool_name LIKE 'whale\_%'
+			);
 		`
 
 	depositorsColumnName        = "f_depositor"

--- a/db/lido.go
+++ b/db/lido.go
@@ -24,10 +24,11 @@ const (
 	`
 
 	identifyLidoValidators = `
-	UPDATE t_identified_validators 
+	UPDATE t_identified_validators
 	SET f_pool_name = t_lido.f_operator
 	FROM t_lido
-	WHERE t_identified_validators.f_validator_pubkey = t_lido.f_validator_pubkey;
+	WHERE t_identified_validators.f_validator_pubkey = t_lido.f_validator_pubkey
+		AND t_identified_validators.f_pool_name IS DISTINCT FROM t_lido.f_operator;
 	`
 	LidoProtocolCurated = "curated"
 	LidoProtocolCSM     = "csm"

--- a/db/migrations/000010_add_deposits_lookup_indexes.down.sql
+++ b/db/migrations/000010_add_deposits_lookup_indexes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_withdrawal_address;
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_depositor;
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_validator_pubkey;

--- a/db/migrations/000010_add_deposits_lookup_indexes.up.sql
+++ b/db/migrations/000010_add_deposits_lookup_indexes.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_withdrawal_address ON public.t_beacon_deposits (f_withdrawal_address);
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_depositor ON public.t_beacon_deposits (f_depositor);
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_validator_pubkey ON public.t_beacon_deposits (f_validator_pubkey);

--- a/db/rocketpool.go
+++ b/db/rocketpool.go
@@ -15,10 +15,11 @@ const (
 	FROM t_rocketpool;
 	`
 	identifyRocketpoolValidators = `
-	UPDATE t_identified_validators 
+	UPDATE t_identified_validators
 	SET f_pool_name = 'rocketpool'
 	FROM t_rocketpool
-	WHERE t_identified_validators.f_validator_pubkey = t_rocketpool.f_validator_pubkey;
+	WHERE t_identified_validators.f_validator_pubkey = t_rocketpool.f_validator_pubkey
+		AND t_identified_validators.f_pool_name IS DISTINCT FROM 'rocketpool';
 	`
 )
 

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -25,8 +25,9 @@ const (
 		INNER JOIN t_withdrawal_address_insert t2
 			ON t1.f_withdrawal_address = t2.f_withdrawal_address
 		WHERE t1.rn = 1
-		ON CONFLICT (f_validator_pubkey) DO UPDATE SET 
-			f_pool_name = EXCLUDED.f_pool_name;
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_pool_name = EXCLUDED.f_pool_name
+		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ALCHEMY_URL=${ALCHEMY_URL}
       - WHALE_THRESHOLD=${WHALE_THRESHOLD}
       - ONLY_DEPOSITS=${ONLY_DEPOSITS:-false}
+      - RECREATE_TABLE=${RECREATE_TABLE:-false}
     network_mode: "host"
     depends_on:
       db:

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,12 @@ else
     ./eth_pokhar beacon_depositors_transactions --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} || exit 1
 fi
 
-./eth_pokhar identify --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} --recreate-table --whale-threshold=${WHALE_THRESHOLD} || exit 1
+# RECREATE_TABLE=true truncates t_identified_validators and rebuilds it from
+# scratch. Meant for methodology changes or a periodic (e.g. weekly) full
+# rebuild; daily runs should be incremental (default).
+RECREATE_FLAG=""
+if [ "${RECREATE_TABLE:-false}" = "true" ]; then
+    RECREATE_FLAG="--recreate-table"
+fi
+
+./eth_pokhar identify --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} ${RECREATE_FLAG} --whale-threshold=${WHALE_THRESHOLD} || exit 1


### PR DESCRIPTION
Makes the daily labeling run incremental instead of a full rebuild. Measured breakdown of last night's run (1h58m total): whales 42m, lido 30m, depositors insert 21m, add new validators 10m, withdrawal insert 8m, coinbase 4m. All of it reprocesses 2.3M validators from scratch every night because `run.sh` hardcodes `--recreate-table`, a flag whose own description says it is meant for methodology changes. Side effects measured on production: `t_identified_validators` bloated to 1.3 GB for 2.3M small rows, and manual corrections wiped every night (as documented in #28).

## Changes

1. **`RECREATE_TABLE` env var (default false)** drives `--recreate-table` in `run.sh` and the compose file. Recommended schedule after this lands: daily incremental run, plus a weekly run with `RECREATE_TABLE=true` to propagate methodology changes and removals from the insert tables.
2. **Write-avoidance guards on every tagging phase**: Postgres rewrites a row even when the new value equals the old one, so with the truncate gone the phases would still churn millions of identical writes. All updates and upsert conflict actions now include `IS DISTINCT FROM` guards and only touch rows whose tag actually changes.
3. **The whales update only touches weakly tagged validators** (null, empty, `solo_stakers`, `whale_*`). Without this, whales would re-tag strongly tagged validators (for example the entire Lido set, whose shared withdrawal vault is a whale address) on every incremental run, and the later phases would flip them back: millions of wasted writes per night. Under a full rebuild the semantics are identical to today, since `AddNewValidators` seeds every validator as `solo_stakers` before whales runs.
4. **Migration 000010**: indexes on `t_beacon_deposits(f_withdrawal_address)`, `(f_depositor)` and `(f_validator_pubkey)`. The whale aggregations and the latest-deposit window scans currently run as sequential scans with large sorts; the table only has its primary key.

## Expected result

Daily run drops from ~2h to roughly the Lido on-chain scan (~30m) plus minutes of SQL; the Lido scan is the next optimization target (incremental key fetching per module) and is not touched here. Write volume per night drops from millions of rows to the actual tag changes (thousands).

## Deploy notes

- One-time after switching to incremental: `VACUUM (FULL, ANALYZE) t_identified_validators;` at a quiet hour to reclaim the accumulated bloat (~1.3 GB down to a few hundred MB). Not required for correctness.
- The migration builds three indexes on a 2.5M row table (seconds to low minutes, taken at container start).
- Update the scheduler to add the weekly `RECREATE_TABLE=true` run.

Refs #17, #28
