### PR TITLE
perf(db): materialize latest deposit per validator to remove window scans from identify

### DIFF
--- a/db/beacon_deposits.go
+++ b/db/beacon_deposits.go
@@ -65,8 +65,16 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 	defer conn.Release()
 
+	// Deposits and the t_validator_last_deposit refresh commit atomically so
+	// the materialized table never drifts from t_beacon_deposits.
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		wlog.Fatalf("could not begin transaction: %s", err.Error())
+	}
+	defer tx.Rollback(p.ctx)
+
 	// Create a temporary table with a unique constraint
-	_, err = conn.Exec(p.ctx, `
+	_, err = tx.Exec(p.ctx, `
         CREATE TEMP TABLE IF NOT EXISTS `+tempTableName+` (
             f_block_num bigint,
             f_depositor text,
@@ -80,7 +88,7 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 
 	// Copy data into the temporary table, ignoring duplicates
-	_, err = conn.CopyFrom(
+	_, err = tx.CopyFrom(
 		p.ctx,
 		pgx.Identifier{tempTableName},
 		[]string{"f_block_num", "f_depositor", "f_tx_hash", "f_validator_pubkey", "f_withdrawal_address"},
@@ -91,7 +99,7 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 
 	// Insert non-duplicate rows from the temporary table into the target table
-	count, err := conn.Exec(p.ctx, `
+	count, err := tx.Exec(p.ctx, `
         INSERT INTO t_beacon_deposits (f_block_num, f_depositor, f_tx_hash, f_validator_pubkey, f_withdrawal_address)
         SELECT f_block_num, f_depositor, f_tx_hash, f_validator_pubkey, f_withdrawal_address
         FROM `+tempTableName+`
@@ -101,10 +109,20 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 		wlog.Fatalf("could not insert rows into target table: %s", err.Error())
 	}
 
+	if count.RowsAffected() > 0 {
+		if err := p.upsertValidatorLastDeposit(tx, tempTableName); err != nil {
+			wlog.Fatalf("could not refresh t_validator_last_deposit: %s", err.Error())
+		}
+	}
+
 	// Drop the temporary table
-	_, err = conn.Exec(p.ctx, `DROP TABLE IF EXISTS `+tempTableName)
+	_, err = tx.Exec(p.ctx, `DROP TABLE IF EXISTS `+tempTableName)
 	if err != nil {
 		wlog.Fatalf("could not drop temporary table: %s", err.Error())
+	}
+
+	if err := tx.Commit(p.ctx); err != nil {
+		wlog.Fatalf("could not commit deposits transaction: %s", err.Error())
 	}
 	if count.RowsAffected() > 0 {
 		wlog.Debugf("persisted %d rows in %f seconds", count.RowsAffected(), time.Since(startTime).Seconds())

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -8,22 +8,12 @@ const (
 			f_validator_pubkey,
 			f_pool_name
 		)
-		SELECT DISTINCT 
-			t1.f_validator_pubkey, 
-			t2.f_pool_name 
-		FROM (
-			SELECT 
-				f_validator_pubkey,
-				f_depositor,
-				ROW_NUMBER() OVER (
-					PARTITION BY f_validator_pubkey 
-					ORDER BY f_block_num DESC
-				) as rn
-			FROM t_beacon_deposits
-		) t1
-		INNER JOIN t_depositors_insert t2 
-			ON t1.f_depositor = t2.f_depositor
-		WHERE t1.rn = 1
+		SELECT
+			v.f_validator_pubkey,
+			m.f_pool_name
+		FROM t_validator_last_deposit v
+		INNER JOIN t_depositors_insert m
+			ON v.f_depositor = m.f_depositor
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -9,9 +9,9 @@ import (
 const (
 	addNewValidatorsQuery = `
 		INSERT INTO t_identified_validators (f_validator_pubkey, f_pool_name)
-		SELECT DISTINCT F_VALIDATOR_PUBKEY, 'solo_stakers'::text
-		FROM T_BEACON_DEPOSITS
-		WHERE F_VALIDATOR_PUBKEY != ''
+		SELECT f_validator_pubkey, 'solo_stakers'::text
+		FROM t_validator_last_deposit
+		WHERE f_validator_pubkey != ''
 		ON CONFLICT (f_validator_pubkey) DO NOTHING;
 	`
 	truncateIdentifiedValidatorsQuery = `

--- a/db/migrations/000011_create_validator_last_deposit_table.down.sql
+++ b/db/migrations/000011_create_validator_last_deposit_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.t_validator_last_deposit;

--- a/db/migrations/000011_create_validator_last_deposit_table.up.sql
+++ b/db/migrations/000011_create_validator_last_deposit_table.up.sql
@@ -1,0 +1,54 @@
+-- Materialized index of the latest deposit facts per validator, kept up to
+-- date incrementally by CopyBeaconDeposits. Depositor and withdrawal address
+-- are tracked separately: rows downloaded before migration 000008 have
+-- f_withdrawal_address = '' forever, so the latest row overall and the latest
+-- row with a non-empty withdrawal address can differ for the same validator.
+CREATE TABLE IF NOT EXISTS public.t_validator_last_deposit (
+    f_validator_pubkey TEXT NOT NULL,
+    f_depositor TEXT NOT NULL,
+    f_depositor_block BIGINT NOT NULL,
+    f_withdrawal_address TEXT NOT NULL DEFAULT '',
+    f_withdrawal_block BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT t_validator_last_deposit_pkey PRIMARY KEY (f_validator_pubkey)
+);
+
+CREATE INDEX IF NOT EXISTS idx_t_validator_last_deposit_f_depositor
+    ON public.t_validator_last_deposit (f_depositor);
+CREATE INDEX IF NOT EXISTS idx_t_validator_last_deposit_f_withdrawal_address
+    ON public.t_validator_last_deposit (f_withdrawal_address);
+
+-- Backfill from the current contents of t_beacon_deposits. Mirrors
+-- rebuildValidatorLastDepositQuery in db/validator_last_deposit.go.
+INSERT INTO t_validator_last_deposit (
+    f_validator_pubkey,
+    f_depositor,
+    f_depositor_block,
+    f_withdrawal_address,
+    f_withdrawal_block
+)
+SELECT
+    ld.f_validator_pubkey,
+    ld.f_depositor,
+    ld.f_block_num,
+    COALESCE(lw.f_withdrawal_address, ''),
+    COALESCE(lw.f_block_num, 0)
+FROM (
+    SELECT DISTINCT ON (f_validator_pubkey)
+        f_validator_pubkey,
+        f_depositor,
+        f_block_num
+    FROM t_beacon_deposits
+    ORDER BY f_validator_pubkey, f_block_num DESC
+) ld
+LEFT JOIN (
+    SELECT DISTINCT ON (f_validator_pubkey)
+        f_validator_pubkey,
+        f_withdrawal_address,
+        f_block_num
+    FROM t_beacon_deposits
+    WHERE f_withdrawal_address != ''
+    ORDER BY f_validator_pubkey, f_block_num DESC
+) lw ON ld.f_validator_pubkey = lw.f_validator_pubkey
+ON CONFLICT (f_validator_pubkey) DO NOTHING;
+
+ANALYZE t_validator_last_deposit;

--- a/db/validator_last_deposit.go
+++ b/db/validator_last_deposit.go
@@ -1,0 +1,156 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	pgx "github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+)
+
+const (
+	// Both statements deduplicate the batch with DISTINCT ON before upserting:
+	// a batch can carry several deposits for the same validator and Postgres
+	// rejects ON CONFLICT DO UPDATE statements that touch a row twice. The
+	// <= guards keep the upserts idempotent when the downloader re-scans the
+	// last blocks and replays deposits already applied.
+	upsertLastDepositorQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT DISTINCT ON (f_validator_pubkey)
+			f_validator_pubkey,
+			f_depositor,
+			f_block_num,
+			'',
+			0
+		FROM %s
+		ORDER BY f_validator_pubkey, f_block_num DESC
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_depositor = EXCLUDED.f_depositor,
+			f_depositor_block = EXCLUDED.f_depositor_block
+		WHERE t_validator_last_deposit.f_depositor_block <= EXCLUDED.f_depositor_block;
+	`
+
+	upsertLastWithdrawalQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT DISTINCT ON (f_validator_pubkey)
+			f_validator_pubkey,
+			f_depositor,
+			f_block_num,
+			f_withdrawal_address,
+			f_block_num
+		FROM %s
+		WHERE f_withdrawal_address != ''
+		ORDER BY f_validator_pubkey, f_block_num DESC
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_withdrawal_address = EXCLUDED.f_withdrawal_address,
+			f_withdrawal_block = EXCLUDED.f_withdrawal_block
+		WHERE t_validator_last_deposit.f_withdrawal_block <= EXCLUDED.f_withdrawal_block;
+	`
+
+	// Mirrors the backfill in migration 000011.
+	rebuildValidatorLastDepositQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT
+			ld.f_validator_pubkey,
+			ld.f_depositor,
+			ld.f_block_num,
+			COALESCE(lw.f_withdrawal_address, ''),
+			COALESCE(lw.f_block_num, 0)
+		FROM (
+			SELECT DISTINCT ON (f_validator_pubkey)
+				f_validator_pubkey,
+				f_depositor,
+				f_block_num
+			FROM t_beacon_deposits
+			ORDER BY f_validator_pubkey, f_block_num DESC
+		) ld
+		LEFT JOIN (
+			SELECT DISTINCT ON (f_validator_pubkey)
+				f_validator_pubkey,
+				f_withdrawal_address,
+				f_block_num
+			FROM t_beacon_deposits
+			WHERE f_withdrawal_address != ''
+			ORDER BY f_validator_pubkey, f_block_num DESC
+		) lw ON ld.f_validator_pubkey = lw.f_validator_pubkey;
+	`
+)
+
+// upsertValidatorLastDeposit refreshes t_validator_last_deposit from a batch
+// of freshly downloaded deposits sitting in tempTableName. It must run inside
+// the same transaction that inserts the batch into t_beacon_deposits so the
+// two tables never drift apart.
+func (p *PostgresDBService) upsertValidatorLastDeposit(tx pgx.Tx, tempTableName string) error {
+	_, err := tx.Exec(p.ctx, fmt.Sprintf(upsertLastDepositorQuery, tempTableName))
+	if err != nil {
+		return errors.Wrap(err, "error upserting last depositor per validator")
+	}
+
+	_, err = tx.Exec(p.ctx, fmt.Sprintf(upsertLastWithdrawalQuery, tempTableName))
+	if err != nil {
+		return errors.Wrap(err, "error upserting last withdrawal address per validator")
+	}
+
+	return nil
+}
+
+// RebuildValidatorLastDeposit rebuilds t_validator_last_deposit from scratch
+// out of t_beacon_deposits. Meant for the periodic full rebuild (identify with
+// --recreate-table), as a safety valve against any drift.
+func (p *PostgresDBService) RebuildValidatorLastDeposit() error {
+	p.writerThreadsWG.Add(1)
+	defer p.writerThreadsWG.Done()
+	startTime := time.Now()
+
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return errors.Wrap(err, "error acquiring connection")
+	}
+	defer conn.Release()
+
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		return errors.Wrap(err, "error beginning rebuild transaction")
+	}
+	defer tx.Rollback(p.ctx)
+
+	_, err = tx.Exec(p.ctx, `TRUNCATE TABLE t_validator_last_deposit;`)
+	if err != nil {
+		return errors.Wrap(err, "error truncating t_validator_last_deposit")
+	}
+
+	_, err = tx.Exec(p.ctx, rebuildValidatorLastDepositQuery)
+	if err != nil {
+		return errors.Wrap(err, "error rebuilding t_validator_last_deposit")
+	}
+
+	if err := tx.Commit(p.ctx); err != nil {
+		return errors.Wrap(err, "error committing rebuild transaction")
+	}
+
+	_, err = conn.Exec(p.ctx, `ANALYZE t_validator_last_deposit;`)
+	if err != nil {
+		return errors.Wrap(err, "error analyzing t_validator_last_deposit")
+	}
+
+	wlog.Infof("rebuilt t_validator_last_deposit in %.2f seconds", time.Since(startTime).Seconds())
+	return nil
+}

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -8,23 +8,13 @@ const (
 			f_validator_pubkey,
 			f_pool_name
 		)
-		SELECT DISTINCT 
-			t1.f_validator_pubkey, 
-			t2.f_pool_name 
-		FROM (
-			SELECT 
-				f_validator_pubkey,
-				f_withdrawal_address,
-				ROW_NUMBER() OVER (
-					PARTITION BY f_validator_pubkey 
-					ORDER BY f_block_num DESC
-				) as rn
-			FROM t_beacon_deposits
-			WHERE f_withdrawal_address!=''
-		) t1
-		INNER JOIN t_withdrawal_address_insert t2
-			ON t1.f_withdrawal_address = t2.f_withdrawal_address
-		WHERE t1.rn = 1
+		SELECT
+			v.f_validator_pubkey,
+			m.f_pool_name
+		FROM t_validator_last_deposit v
+		INNER JOIN t_withdrawal_address_insert m
+			ON v.f_withdrawal_address = m.f_withdrawal_address
+		WHERE v.f_withdrawal_address != ''
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/identify/identify.go
+++ b/identify/identify.go
@@ -71,8 +71,15 @@ func (i *Identify) Run() {
 
 	if i.iConfig.RecreateTable && !i.stop {
 		startTime := time.Now()
+		// Full rebuilds also refresh t_validator_last_deposit from scratch, as
+		// a periodic safety valve against any drift in the incremental upserts.
+		log.Info("Rebuilding validator last deposit table")
+		err := i.dbClient.RebuildValidatorLastDeposit()
+		if err != nil {
+			log.Errorf("Error rebuilding validator last deposit table: %v. Skipping to next step.", err)
+		}
 		log.Info("Truncating identified validators table")
-		err := i.dbClient.TruncateIdentifiedValidators()
+		err = i.dbClient.TruncateIdentifiedValidators()
 		if err != nil {
 			log.Errorf("Error truncating identified validators table: %v. Skipping to next step.", err)
 		} else {


### PR DESCRIPTION
## Problem

The two heaviest phases of the identify run recompute the latest deposit per validator on every execution with a window function over the whole t_beacon_deposits table (2.5M rows):

- ApplyDepositorsInsert: `ROW_NUMBER() OVER (PARTITION BY f_validator_pubkey ORDER BY f_block_num DESC)`, ~5m40s per run
- ApplyWithdrawalAddressInsert: same window scan again with a `f_withdrawal_address != ''` filter, ~4m30s per run
- AddNewValidators: `SELECT DISTINCT f_validator_pubkey` over the same table, ~2m20s per run

The latest deposit facts barely change between runs, so this is repeated work.

## Change

New table `t_validator_last_deposit` (one row per validator) that stores the latest depositor and the latest non-empty withdrawal address, each with its block number. The two facts are tracked separately because rows downloaded before migration 000008 keep an empty withdrawal address forever, so the latest row overall and the latest row with a withdrawal address can differ.

- Migration 000011 creates the table, backfills it from t_beacon_deposits and indexes f_depositor and f_withdrawal_address.
- CopyBeaconDeposits now runs inside a transaction and refreshes the table from the freshly inserted batch before committing, so both tables stay consistent atomically. The upserts deduplicate the batch with DISTINCT ON and guard with `<=` block comparisons, which makes them idempotent against the re-scan of the last blocks the downloader performs.
- ApplyDepositorsInsert, ApplyWithdrawalAddressInsert and AddNewValidators now read from the new table with plain joins. Same semantics, no window scans.
- Runs with `--recreate-table` rebuild the table from scratch first, as a periodic safety valve against any drift.

## Expected effect

The three phases drop from ~12m30s combined to well under a minute. Semantics are unchanged: the output of the rewritten queries matches the original ones row for row on the same input.

## Rollback

`migrate down 1` drops the table and reverting the merge restores the original queries, which carry no extra state.
