### PR TITLE
fix(beacon-depositors-transactions): wait for deposits collector before closing the pool

### DIFF
--- a/beacon-depositors-transactions/deposits.go
+++ b/beacon-depositors-transactions/deposits.go
@@ -106,7 +106,10 @@ func (b *BeaconDepositorsTransactions) processDepositTransfers(transfers []alche
 		close(transferCh)
 	}()
 
+	var collectorWG sync.WaitGroup
+	collectorWG.Add(1)
 	go func() {
+		defer collectorWG.Done()
 		var deposits []models.BeaconDeposit
 		for deposit := range depositsCh {
 			deposits = append(deposits, deposit)
@@ -128,6 +131,11 @@ func (b *BeaconDepositorsTransactions) processDepositTransfers(transfers []alche
 		}
 	}
 	close(depositsCh)
+
+	// Wait for the collector to persist the batch before returning: the caller
+	// tears down the DB pool right after this routine, and an unawaited
+	// collector still writing would race it and hit a closed pool.
+	collectorWG.Wait()
 
 	return nil
 }


### PR DESCRIPTION
## Problem

The goroutine that drains the deposits channel and persists the batch via CopyBeaconDeposits is never awaited: processDepositTransfers returns right after closing the channel. The caller then tears down the DB pool, and if the collector has not yet registered itself in the writer wait group (its first statement), the shutdown wins the race and the collector dies with:

    level=fatal msg="could not acquire connection: closed pool" module=postgres-db

This race is as old as the collector itself and just surfaced in a run today (the retry wrapper hid it until now). No data is lost thanks to the re-scan of the last blocks, but the process exits with code 1 and burns a retry attempt.

## Change

Give the collector its own WaitGroup and wait for it after closing the deposits channel, so the batch is fully persisted before the routine returns and connections are closed.

## Verification

Build and vet pass. The failure mode is timing dependent; with the wait in place the ordering is deterministic and the race cannot occur.