### PR TITLE
perf(identify): prune upsert probes with anti-joins and single lido pool-name pass

### DIFF
--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -14,6 +14,10 @@ const (
 		FROM t_validator_last_deposit v
 		INNER JOIN t_depositors_insert m
 			ON v.f_depositor = m.f_depositor
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
+		WHERE t.f_validator_pubkey IS NULL
+			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -9,9 +9,12 @@ import (
 const (
 	addNewValidatorsQuery = `
 		INSERT INTO t_identified_validators (f_validator_pubkey, f_pool_name)
-		SELECT f_validator_pubkey, 'solo_stakers'::text
-		FROM t_validator_last_deposit
-		WHERE f_validator_pubkey != ''
+		SELECT v.f_validator_pubkey, 'solo_stakers'::text
+		FROM t_validator_last_deposit v
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
+		WHERE t.f_validator_pubkey IS NULL
+			AND v.f_validator_pubkey != ''
 		ON CONFLICT (f_validator_pubkey) DO NOTHING;
 	`
 	truncateIdentifiedValidatorsQuery = `

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -14,7 +14,11 @@ const (
 		FROM t_validator_last_deposit v
 		INNER JOIN t_withdrawal_address_insert m
 			ON v.f_withdrawal_address = m.f_withdrawal_address
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
 		WHERE v.f_withdrawal_address != ''
+			AND (t.f_validator_pubkey IS NULL
+				OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/identify/lido.go
+++ b/identify/lido.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	db "github.com/migalabs/eth-pokhar/db"
 	"github.com/migalabs/eth-pokhar/lido"
@@ -76,6 +77,16 @@ func (i *Identify) IdentifyLidoValidators() error {
 	}
 	log.Debug("Identified lido csm validators")
 
+	// One single pass over t_lido after the three modules updated it: the
+	// UPDATE joins half a million keys against t_identified_validators, so
+	// running it per module tripled the cost for the same final state.
+	startTime := time.Now()
+	err = i.dbClient.IdentifyLidoValidators()
+	if err != nil {
+		return err
+	}
+	log.Infof("Applied lido pool names in %v", time.Since(startTime))
+
 	return nil
 }
 
@@ -125,10 +136,6 @@ func (i *Identify) identifySDVT(keyCounts map[string]uint64) error {
 	log.Infof("SDVT module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -237,13 +244,6 @@ func (i *Identify) identifyCSM(keyCounts map[string]uint64) error {
 	log.Infof("CSM module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
-	log.Debug("Identifying lido curated validators")
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
-	log.Debug("Identified lido validators")
-
 	return nil
 }
 
@@ -343,13 +343,6 @@ func (i *Identify) identifyCuratedModule(keyCounts map[string]uint64) error {
 	}
 	log.Infof("Curated module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
-
-	log.Debug("Identifying lido curated validators")
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
-	log.Debug("Identified lido validators")
 
 	return nil
 }


### PR DESCRIPTION
## Problem

Benchmarking after #36 and #37 left the identify run at ~13m30s, with three phases dominated by the same pattern: work proportional to the table size instead of to the actual daily changes.

- AddNewValidators and ApplyDepositorsInsert feed millions of candidate rows into INSERT ON CONFLICT, which probes the primary key index of t_identified_validators once per candidate just to discard nearly all of them (2.36M probes to insert a few dozen rows).
- The Lido phase runs the global pool-name UPDATE (t_lido joined against t_identified_validators, half a million keys) once per module, three times per run, for the same final state.

## Change

- AddNewValidators: anti-join against t_identified_validators so only genuinely new pubkeys reach the insert.
- ApplyDepositorsInsert and ApplyWithdrawalAddressInsert: left join against t_identified_validators and keep only rows that are missing or whose pool actually differs, before the upsert. The ON CONFLICT guard stays as the final arbiter, the pre-filter just prunes the probe volume from millions to the real day-to-day delta.
- The lido pool-name UPDATE now runs once after the three modules finish instead of once per module, with its own timing log.

Final state is identical in all three cases; only the amount of index probing and repeated scanning changes.

## Expected effect

AddNewValidators ~2m30s to seconds, depositors insert ~2m30s to seconds, Lido phase drops the two redundant global UPDATE passes (~3 minutes). Projected total run time lands in the 6 to 8 minute range.