### PR TITLE
perf(db): respect phase precedence to remove self-cancelling rewrites

### DIFF
--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -16,8 +16,21 @@ const (
 			ON v.f_depositor = m.f_depositor
 		LEFT JOIN t_identified_validators t
 			ON t.f_validator_pubkey = v.f_validator_pubkey
-		WHERE t.f_validator_pubkey IS NULL
-			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name
+		WHERE (t.f_validator_pubkey IS NULL
+			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
+			-- Skip validators that a later phase claims: it would overwrite the
+			-- tag again in the same run, so writing it here is pure churn that
+			-- the phase order (issue #28) then has to undo.
+			AND t.f_pool_name IS DISTINCT FROM 'coinbase'
+			AND NOT (v.f_withdrawal_address != '' AND EXISTS (
+				SELECT 1 FROM t_withdrawal_address_insert w
+				WHERE w.f_withdrawal_address = v.f_withdrawal_address))
+			AND NOT EXISTS (SELECT 1 FROM t_rocketpool r
+				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_lido l
+				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/validators_insert.go
+++ b/db/validators_insert.go
@@ -13,7 +13,8 @@ const (
 		f_pool_name
 	FROM
 		t_validators_insert
-	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name;
+	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name
+	WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -19,6 +19,15 @@ const (
 		WHERE v.f_withdrawal_address != ''
 			AND (t.f_validator_pubkey IS NULL
 				OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
+			-- Skip validators that a later phase claims (see issue #28): it
+			-- would overwrite the tag again in the same run.
+			AND t.f_pool_name IS DISTINCT FROM 'coinbase'
+			AND NOT EXISTS (SELECT 1 FROM t_rocketpool r
+				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_lido l
+				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;


### PR DESCRIPTION
## Problem

Identify phases resolve precedence positionally: each phase upserts its tags and later phases overwrite them (issue #28). Measured with EXPLAIN ANALYZE on production data, this means every single run:

- The depositors phase rewrites 292,723 rows whose current tag belongs to a later phase (284,565 of them are Lido validators), only for those phases to revert them minutes later in the same run.
- That stomp cascades: the withdrawal phase then rewrites ~129k rows that the depositors stomp just broke, and the Lido pass re-stamps its operators. At rest, the withdrawal set is zero, proving the churn is self-inflicted.
- The final validators insert carries no write guard at all and rewrites its full 83,549 rows every run.

Roughly 500k self-cancelling writes per run: pure WAL, dead tuples (the table needed a full vacuum) and about 4 minutes of runtime. This gets 24x worse if the pipeline ever runs hourly.

## Change

- Depositors and withdrawal inserts now skip candidates that a later phase claims: pubkeys present in t_lido, t_rocketpool or t_validators_insert, validators whose withdrawal address is mapped (depositors only), and rows currently tagged coinbase. The final state is the same one the phase order would produce; the intermediate rewrite and revert disappear.
- The final validators insert gains the same IS DISTINCT FROM write guard the other phases already use.

## Notes on staleness

The claims are read at depositors time, so a validator that leaves a claiming set (for example removed from the Lido registry) keeps its old tag for one extra run, and the weekly recreate-table rebuild replays everything from scratch with original semantics. Same trade-off already accepted for the whales guard and the Lido incremental fetch.

## Expected effect

Depositors phase from ~2m15s to seconds, withdrawal and final insert to near-instant, and per-run write volume drops from ~500k rows to the real daily delta (hundreds). Projected total run time ~4 minutes.