### PR TITLE
release: identify pipeline overhaul, atomic labels sync and precedence fixes

### DIFF
--- a/beacon-depositors-transactions/deposits.go
+++ b/beacon-depositors-transactions/deposits.go
@@ -106,7 +106,10 @@ func (b *BeaconDepositorsTransactions) processDepositTransfers(transfers []alche
 		close(transferCh)
 	}()
 
+	var collectorWG sync.WaitGroup
+	collectorWG.Add(1)
 	go func() {
+		defer collectorWG.Done()
 		var deposits []models.BeaconDeposit
 		for deposit := range depositsCh {
 			deposits = append(deposits, deposit)
@@ -128,6 +131,11 @@ func (b *BeaconDepositorsTransactions) processDepositTransfers(transfers []alche
 		}
 	}
 	close(depositsCh)
+
+	// Wait for the collector to persist the batch before returning: the caller
+	// tears down the DB pool right after this routine, and an unawaited
+	// collector still writing would race it and hit a closed pool.
+	collectorWG.Wait()
 
 	return nil
 }

--- a/beacon-depositors-transactions/routines.go
+++ b/beacon-depositors-transactions/routines.go
@@ -17,11 +17,15 @@ import (
 
 func (b *BeaconDepositorsTransactions) updateDepositorsTransactions() {
 	log.Info("Getting checkpoints")
-	checkpoints, err := b.dbClient.ObtainCheckpointPerDepositor()
+	checkpoints, err := b.dbClient.ObtainCheckpointPerDepositor(b.iConfig.SkipTagged)
 	if err != nil {
 		log.Fatalf("Error obtaining checkpoints: %s", err.Error())
 	}
-	log.Info("Got checkpoints")
+	if b.iConfig.SkipTagged {
+		log.Infof("Got checkpoints for %d depositors with untagged validators (skip-tagged enabled)", len(checkpoints))
+	} else {
+		log.Infof("Got checkpoints for %d depositors", len(checkpoints))
+	}
 
 	log.Info("Fetching new transactions")
 

--- a/cmd/beacon-depositors-transactions/cmd.go
+++ b/cmd/beacon-depositors-transactions/cmd.go
@@ -53,6 +53,11 @@ var BeaconDepositorsTransactionsCommand = &cli.Command{
 			Name:  "only-deposits",
 			Usage: "Only fetch deposits. If not set, it will fetch all new depositor transactions which can take up to 20 hours",
 		},
+		&cli.BoolFlag{
+			Name:    "skip-tagged",
+			Usage:   "Skip fetching transactions for depositors whose validators are all already identified. Transactions are only used to identify coinbase validators, so this saves most Alchemy credits/node calls and runtime; a new deposit brings its depositor back into scope automatically",
+			EnvVars: []string{"SKIP_TAGGED"},
+		},
 	},
 }
 

--- a/config/beacon_depositors_transactions_config.go
+++ b/config/beacon_depositors_transactions_config.go
@@ -11,6 +11,7 @@ type BeaconDepositorsTransactionsConfig struct {
 	Workers      int    `json:"workers-num"`
 	AlchemyURL   string `json:"alchemy-url"`
 	OnlyDeposits bool   `json:"only-deposits"`
+	SkipTagged   bool   `json:"skip-tagged"`
 }
 
 func NewBeaconDepositorsTransactionsConfig() *BeaconDepositorsTransactionsConfig {
@@ -46,6 +47,10 @@ func (c *BeaconDepositorsTransactionsConfig) Apply(ctx *cli.Context) {
 
 	if ctx.IsSet("only-deposits") {
 		c.OnlyDeposits = true
+	}
+
+	if ctx.IsSet("skip-tagged") {
+		c.SkipTagged = true
 	}
 
 }

--- a/db/beacon_depositors_transactions.go
+++ b/db/beacon_depositors_transactions.go
@@ -23,23 +23,54 @@ var (
 		select f_depositor, MAX(f_block_num) f_max_block_num
 		from t_beacon_depositors_transactions
 		group by f_depositor)
-	
+
 	SELECT d.f_depositor, COALESCE(MAX(t.f_max_block_num), 0) f_max_block_num
 		FROM t_beacon_deposits d
 		LEFT JOIN max_block_per_depositor t ON d.f_depositor = t.f_depositor
 		GROUP BY d.f_depositor
 		ORDER BY f_max_block_num ASC;
 	`
+
+	// Same as above, but only depositors with at least one validator whose
+	// tag is weak: missing, empty, whale_* or solo_stakers. Transactions are
+	// only used to identify coinbase validators, and coinbase candidates are
+	// precisely the validators that would otherwise sit in those catch-all
+	// buckets, so depositors whose validators all carry a strong tag do not
+	// need their transfer history refreshed. Every validator gets a row in
+	// t_identified_validators on each identify run, so row existence alone
+	// cannot be used as the filter (see issue #17).
+	selectCheckpointPerUntaggedDepositor = `
+	WITH max_block_per_depositor AS (
+		select f_depositor, MAX(f_block_num) f_max_block_num
+		from t_beacon_depositors_transactions
+		group by f_depositor)
+
+	SELECT d.f_depositor, COALESCE(MAX(t.f_max_block_num), 0) f_max_block_num
+		FROM t_beacon_deposits d
+		LEFT JOIN max_block_per_depositor t ON d.f_depositor = t.f_depositor
+		LEFT JOIN t_identified_validators iv ON iv.f_validator_pubkey = d.f_validator_pubkey
+		GROUP BY d.f_depositor
+		HAVING COUNT(*) FILTER (WHERE iv.f_validator_pubkey IS NULL
+			OR iv.f_pool_name IS NULL
+			OR iv.f_pool_name = ''
+			OR iv.f_pool_name LIKE 'whale\_%'
+			OR iv.f_pool_name = 'solo_stakers') > 0
+		ORDER BY f_max_block_num ASC;
+	`
 )
 
-func (p *PostgresDBService) ObtainCheckpointPerDepositor() ([]models.DepositorCheckpoint, error) {
+func (p *PostgresDBService) ObtainCheckpointPerDepositor(skipTagged bool) ([]models.DepositorCheckpoint, error) {
 	conn, err := p.psqlPool.Acquire(p.ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "error acquiring database connection")
 	}
 	defer conn.Release()
 
-	rows, err := conn.Query(p.ctx, selectCheckpointPerDepositor)
+	query := selectCheckpointPerDepositor
+	if skipTagged {
+		query = selectCheckpointPerUntaggedDepositor
+	}
+	rows, err := conn.Query(p.ctx, query)
 	if err != nil {
 		rows.Close()
 		return nil, err

--- a/db/beacon_deposits.go
+++ b/db/beacon_deposits.go
@@ -65,8 +65,16 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 	defer conn.Release()
 
+	// Deposits and the t_validator_last_deposit refresh commit atomically so
+	// the materialized table never drifts from t_beacon_deposits.
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		wlog.Fatalf("could not begin transaction: %s", err.Error())
+	}
+	defer tx.Rollback(p.ctx)
+
 	// Create a temporary table with a unique constraint
-	_, err = conn.Exec(p.ctx, `
+	_, err = tx.Exec(p.ctx, `
         CREATE TEMP TABLE IF NOT EXISTS `+tempTableName+` (
             f_block_num bigint,
             f_depositor text,
@@ -80,7 +88,7 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 
 	// Copy data into the temporary table, ignoring duplicates
-	_, err = conn.CopyFrom(
+	_, err = tx.CopyFrom(
 		p.ctx,
 		pgx.Identifier{tempTableName},
 		[]string{"f_block_num", "f_depositor", "f_tx_hash", "f_validator_pubkey", "f_withdrawal_address"},
@@ -91,7 +99,7 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 	}
 
 	// Insert non-duplicate rows from the temporary table into the target table
-	count, err := conn.Exec(p.ctx, `
+	count, err := tx.Exec(p.ctx, `
         INSERT INTO t_beacon_deposits (f_block_num, f_depositor, f_tx_hash, f_validator_pubkey, f_withdrawal_address)
         SELECT f_block_num, f_depositor, f_tx_hash, f_validator_pubkey, f_withdrawal_address
         FROM `+tempTableName+`
@@ -101,10 +109,20 @@ func (p *PostgresDBService) CopyBeaconDeposits(rowSrc []models.BeaconDeposit) in
 		wlog.Fatalf("could not insert rows into target table: %s", err.Error())
 	}
 
+	if count.RowsAffected() > 0 {
+		if err := p.upsertValidatorLastDeposit(tx, tempTableName); err != nil {
+			wlog.Fatalf("could not refresh t_validator_last_deposit: %s", err.Error())
+		}
+	}
+
 	// Drop the temporary table
-	_, err = conn.Exec(p.ctx, `DROP TABLE IF EXISTS `+tempTableName)
+	_, err = tx.Exec(p.ctx, `DROP TABLE IF EXISTS `+tempTableName)
 	if err != nil {
 		wlog.Fatalf("could not drop temporary table: %s", err.Error())
+	}
+
+	if err := tx.Commit(p.ctx); err != nil {
+		wlog.Fatalf("could not commit deposits transaction: %s", err.Error())
 	}
 	if count.RowsAffected() > 0 {
 		wlog.Debugf("persisted %d rows in %f seconds", count.RowsAffected(), time.Since(startTime).Seconds())

--- a/db/coinbase.go
+++ b/db/coinbase.go
@@ -54,6 +54,7 @@ const (
 				'd2276af80582cac230edc4c42e9a9c096f3c09aa')
 		)
 	)
+	AND f_pool_name IS DISTINCT FROM 'coinbase'
 	`
 )
 

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -8,22 +8,12 @@ const (
 			f_validator_pubkey,
 			f_pool_name
 		)
-		SELECT DISTINCT 
-			t1.f_validator_pubkey, 
-			t2.f_pool_name 
-		FROM (
-			SELECT 
-				f_validator_pubkey,
-				f_depositor,
-				ROW_NUMBER() OVER (
-					PARTITION BY f_validator_pubkey 
-					ORDER BY f_block_num DESC
-				) as rn
-			FROM t_beacon_deposits
-		) t1
-		INNER JOIN t_depositors_insert t2 
-			ON t1.f_depositor = t2.f_depositor
-		WHERE t1.rn = 1
+		SELECT
+			v.f_validator_pubkey,
+			m.f_pool_name
+		FROM t_validator_last_deposit v
+		INNER JOIN t_depositors_insert m
+			ON v.f_depositor = m.f_depositor
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -24,8 +24,9 @@ const (
 		INNER JOIN t_depositors_insert t2 
 			ON t1.f_depositor = t2.f_depositor
 		WHERE t1.rn = 1
-		ON CONFLICT (f_validator_pubkey) DO UPDATE SET 
-			f_pool_name = EXCLUDED.f_pool_name;
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_pool_name = EXCLUDED.f_pool_name
+		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -16,8 +16,21 @@ const (
 			ON v.f_depositor = m.f_depositor
 		LEFT JOIN t_identified_validators t
 			ON t.f_validator_pubkey = v.f_validator_pubkey
-		WHERE t.f_validator_pubkey IS NULL
-			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name
+		WHERE (t.f_validator_pubkey IS NULL
+			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
+			-- Skip validators that a later phase claims: it would overwrite the
+			-- tag again in the same run, so writing it here is pure churn that
+			-- the phase order (issue #28) then has to undo.
+			AND t.f_pool_name IS DISTINCT FROM 'coinbase'
+			AND NOT (v.f_withdrawal_address != '' AND EXISTS (
+				SELECT 1 FROM t_withdrawal_address_insert w
+				WHERE w.f_withdrawal_address = v.f_withdrawal_address))
+			AND NOT EXISTS (SELECT 1 FROM t_rocketpool r
+				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_lido l
+				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -14,6 +14,10 @@ const (
 		FROM t_validator_last_deposit v
 		INNER JOIN t_depositors_insert m
 			ON v.f_depositor = m.f_depositor
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
+		WHERE t.f_validator_pubkey IS NULL
+			OR t.f_pool_name IS DISTINCT FROM m.f_pool_name
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -9,9 +9,12 @@ import (
 const (
 	addNewValidatorsQuery = `
 		INSERT INTO t_identified_validators (f_validator_pubkey, f_pool_name)
-		SELECT f_validator_pubkey, 'solo_stakers'::text
-		FROM t_validator_last_deposit
-		WHERE f_validator_pubkey != ''
+		SELECT v.f_validator_pubkey, 'solo_stakers'::text
+		FROM t_validator_last_deposit v
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
+		WHERE t.f_validator_pubkey IS NULL
+			AND v.f_validator_pubkey != ''
 		ON CONFLICT (f_validator_pubkey) DO NOTHING;
 	`
 	truncateIdentifiedValidatorsQuery = `

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -57,7 +57,14 @@ const (
 				F_VALIDATOR_PUBKEY != ''
 		) AS subquery2
 		WHERE 
-			t_identified_validators.f_validator_pubkey = subquery2.f_validator_pubkey;
+			t_identified_validators.f_validator_pubkey = subquery2.f_validator_pubkey
+			AND t_identified_validators.f_pool_name IS DISTINCT FROM subquery2.whale_id
+			AND (
+				t_identified_validators.f_pool_name IS NULL
+				OR t_identified_validators.f_pool_name = ''
+				OR t_identified_validators.f_pool_name = 'solo_stakers'
+				OR t_identified_validators.f_pool_name LIKE 'whale\_%'
+			);
 		`
 
 	depositorsColumnName        = "f_depositor"

--- a/db/identified_validators.go
+++ b/db/identified_validators.go
@@ -9,9 +9,9 @@ import (
 const (
 	addNewValidatorsQuery = `
 		INSERT INTO t_identified_validators (f_validator_pubkey, f_pool_name)
-		SELECT DISTINCT F_VALIDATOR_PUBKEY, 'solo_stakers'::text
-		FROM T_BEACON_DEPOSITS
-		WHERE F_VALIDATOR_PUBKEY != ''
+		SELECT f_validator_pubkey, 'solo_stakers'::text
+		FROM t_validator_last_deposit
+		WHERE f_validator_pubkey != ''
 		ON CONFLICT (f_validator_pubkey) DO NOTHING;
 	`
 	truncateIdentifiedValidatorsQuery = `

--- a/db/lido.go
+++ b/db/lido.go
@@ -24,10 +24,11 @@ const (
 	`
 
 	identifyLidoValidators = `
-	UPDATE t_identified_validators 
+	UPDATE t_identified_validators
 	SET f_pool_name = t_lido.f_operator
 	FROM t_lido
-	WHERE t_identified_validators.f_validator_pubkey = t_lido.f_validator_pubkey;
+	WHERE t_identified_validators.f_validator_pubkey = t_lido.f_validator_pubkey
+		AND t_identified_validators.f_pool_name IS DISTINCT FROM t_lido.f_operator;
 	`
 	LidoProtocolCurated = "curated"
 	LidoProtocolCSM     = "csm"

--- a/db/lido.go
+++ b/db/lido.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -160,6 +161,117 @@ func (p *PostgresDBService) ReconcileLidoOperatorValidators(operator string, ope
 			operator, protocol, upserted, removed, time.Since(startTime).Seconds())
 	}
 	return upserted, removed, nil
+}
+
+// LidoOperatorCountKey builds the lookup key used by the map returned from
+// ObtainLidoOperatorKeyCounts.
+func LidoOperatorCountKey(protocol string, operatorIndex uint64) string {
+	return fmt.Sprintf("%s/%d", protocol, operatorIndex)
+}
+
+// ObtainLidoOperatorKeyCounts returns how many keys t_lido currently holds per
+// (protocol, operator index). Used as the checkpoint to decide whether an
+// operator needs no work, an incremental key fetch or a full reconcile.
+func (p *PostgresDBService) ObtainLidoOperatorKeyCounts() (map[string]uint64, error) {
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "error acquiring database connection")
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(p.ctx, `
+		SELECT f_protocol, f_operator_index, count(*)
+		FROM t_lido
+		GROUP BY f_protocol, f_operator_index;
+	`)
+	if err != nil {
+		return nil, errors.Wrap(err, "error obtaining lido operator key counts")
+	}
+	defer rows.Close()
+
+	counts := make(map[string]uint64)
+	for rows.Next() {
+		var protocol string
+		var operatorIndex int64
+		var count int64
+		if err := rows.Scan(&protocol, &operatorIndex, &count); err != nil {
+			return nil, errors.Wrap(err, "error scanning lido operator key count")
+		}
+		counts[LidoOperatorCountKey(protocol, uint64(operatorIndex))] = uint64(count)
+	}
+	return counts, nil
+}
+
+// AppendLidoOperatorValidators upserts a batch of keys for an operator WITHOUT
+// removing anything. Meant for the incremental path, where only the keys added
+// on-chain since the last run are fetched: passing such a partial set to
+// ReconcileLidoOperatorValidators would delete every previously stored key of
+// the operator, so removals are handled exclusively by the full reconcile.
+func (p *PostgresDBService) AppendLidoOperatorValidators(operator string, operatorIndex uint64, newKeys []string, protocol string) (int64, error) {
+	if len(newKeys) == 0 {
+		return 0, nil
+	}
+	p.writerThreadsWG.Add(1)
+	defer p.writerThreadsWG.Done()
+	startTime := time.Now()
+
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "error acquiring database connection")
+	}
+	defer conn.Release()
+
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "error beginning transaction")
+	}
+	defer tx.Rollback(p.ctx)
+
+	tempTableName := "tmp_lido_append_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
+	_, err = tx.Exec(p.ctx, `
+		CREATE TEMP TABLE `+tempTableName+` (
+			f_validator_pubkey text PRIMARY KEY
+		) ON COMMIT DROP;
+	`)
+	if err != nil {
+		return 0, errors.Wrap(err, "error creating temp table")
+	}
+
+	rows := make([][]interface{}, len(newKeys))
+	for i, k := range newKeys {
+		rows[i] = []interface{}{k}
+	}
+	_, err = tx.CopyFrom(p.ctx, pgx.Identifier{tempTableName}, []string{"f_validator_pubkey"}, pgx.CopyFromRows(rows))
+	if err != nil {
+		return 0, errors.Wrap(err, "error copying new keys into temp table")
+	}
+
+	insCmd, err := tx.Exec(p.ctx, `
+		INSERT INTO t_lido (f_validator_pubkey, f_operator, f_operator_index, f_protocol)
+		SELECT t.f_validator_pubkey, $1, $2, $3
+		FROM `+tempTableName+` t
+		ON CONFLICT (f_validator_pubkey) DO UPDATE
+			SET f_operator = EXCLUDED.f_operator,
+			    f_operator_index = EXCLUDED.f_operator_index,
+			    f_protocol = EXCLUDED.f_protocol
+		WHERE t_lido.f_operator       IS DISTINCT FROM EXCLUDED.f_operator
+		   OR t_lido.f_operator_index IS DISTINCT FROM EXCLUDED.f_operator_index
+		   OR t_lido.f_protocol       IS DISTINCT FROM EXCLUDED.f_protocol;
+	`, operator, operatorIndex, protocol)
+	if err != nil {
+		return 0, errors.Wrap(err, "error appending new keys")
+	}
+	upserted := insCmd.RowsAffected()
+
+	if err := tx.Commit(p.ctx); err != nil {
+		return 0, errors.Wrap(err, "error committing append transaction")
+	}
+
+	if upserted > 0 {
+		wlog.Debugf("appended %d keys for operator %v (proto=%v) in %.2fs",
+			upserted, operator, protocol, time.Since(startTime).Seconds())
+	}
+	return upserted, nil
 }
 
 // CopyLidoOperatorValidators copies the validators to the database for a given operator

--- a/db/migrations/000010_add_deposits_lookup_indexes.down.sql
+++ b/db/migrations/000010_add_deposits_lookup_indexes.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_withdrawal_address;
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_depositor;
+DROP INDEX IF EXISTS idx_t_beacon_deposits_f_validator_pubkey;

--- a/db/migrations/000010_add_deposits_lookup_indexes.up.sql
+++ b/db/migrations/000010_add_deposits_lookup_indexes.up.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_withdrawal_address ON public.t_beacon_deposits (f_withdrawal_address);
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_depositor ON public.t_beacon_deposits (f_depositor);
+CREATE INDEX IF NOT EXISTS idx_t_beacon_deposits_f_validator_pubkey ON public.t_beacon_deposits (f_validator_pubkey);

--- a/db/migrations/000011_create_validator_last_deposit_table.down.sql
+++ b/db/migrations/000011_create_validator_last_deposit_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.t_validator_last_deposit;

--- a/db/migrations/000011_create_validator_last_deposit_table.up.sql
+++ b/db/migrations/000011_create_validator_last_deposit_table.up.sql
@@ -1,0 +1,54 @@
+-- Materialized index of the latest deposit facts per validator, kept up to
+-- date incrementally by CopyBeaconDeposits. Depositor and withdrawal address
+-- are tracked separately: rows downloaded before migration 000008 have
+-- f_withdrawal_address = '' forever, so the latest row overall and the latest
+-- row with a non-empty withdrawal address can differ for the same validator.
+CREATE TABLE IF NOT EXISTS public.t_validator_last_deposit (
+    f_validator_pubkey TEXT NOT NULL,
+    f_depositor TEXT NOT NULL,
+    f_depositor_block BIGINT NOT NULL,
+    f_withdrawal_address TEXT NOT NULL DEFAULT '',
+    f_withdrawal_block BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT t_validator_last_deposit_pkey PRIMARY KEY (f_validator_pubkey)
+);
+
+CREATE INDEX IF NOT EXISTS idx_t_validator_last_deposit_f_depositor
+    ON public.t_validator_last_deposit (f_depositor);
+CREATE INDEX IF NOT EXISTS idx_t_validator_last_deposit_f_withdrawal_address
+    ON public.t_validator_last_deposit (f_withdrawal_address);
+
+-- Backfill from the current contents of t_beacon_deposits. Mirrors
+-- rebuildValidatorLastDepositQuery in db/validator_last_deposit.go.
+INSERT INTO t_validator_last_deposit (
+    f_validator_pubkey,
+    f_depositor,
+    f_depositor_block,
+    f_withdrawal_address,
+    f_withdrawal_block
+)
+SELECT
+    ld.f_validator_pubkey,
+    ld.f_depositor,
+    ld.f_block_num,
+    COALESCE(lw.f_withdrawal_address, ''),
+    COALESCE(lw.f_block_num, 0)
+FROM (
+    SELECT DISTINCT ON (f_validator_pubkey)
+        f_validator_pubkey,
+        f_depositor,
+        f_block_num
+    FROM t_beacon_deposits
+    ORDER BY f_validator_pubkey, f_block_num DESC
+) ld
+LEFT JOIN (
+    SELECT DISTINCT ON (f_validator_pubkey)
+        f_validator_pubkey,
+        f_withdrawal_address,
+        f_block_num
+    FROM t_beacon_deposits
+    WHERE f_withdrawal_address != ''
+    ORDER BY f_validator_pubkey, f_block_num DESC
+) lw ON ld.f_validator_pubkey = lw.f_validator_pubkey
+ON CONFLICT (f_validator_pubkey) DO NOTHING;
+
+ANALYZE t_validator_last_deposit;

--- a/db/rocketpool.go
+++ b/db/rocketpool.go
@@ -15,10 +15,11 @@ const (
 	FROM t_rocketpool;
 	`
 	identifyRocketpoolValidators = `
-	UPDATE t_identified_validators 
+	UPDATE t_identified_validators
 	SET f_pool_name = 'rocketpool'
 	FROM t_rocketpool
-	WHERE t_identified_validators.f_validator_pubkey = t_rocketpool.f_validator_pubkey;
+	WHERE t_identified_validators.f_validator_pubkey = t_rocketpool.f_validator_pubkey
+		AND t_identified_validators.f_pool_name IS DISTINCT FROM 'rocketpool';
 	`
 )
 

--- a/db/validator_last_deposit.go
+++ b/db/validator_last_deposit.go
@@ -1,0 +1,156 @@
+package db
+
+import (
+	"fmt"
+	"time"
+
+	pgx "github.com/jackc/pgx/v5"
+	"github.com/pkg/errors"
+)
+
+const (
+	// Both statements deduplicate the batch with DISTINCT ON before upserting:
+	// a batch can carry several deposits for the same validator and Postgres
+	// rejects ON CONFLICT DO UPDATE statements that touch a row twice. The
+	// <= guards keep the upserts idempotent when the downloader re-scans the
+	// last blocks and replays deposits already applied.
+	upsertLastDepositorQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT DISTINCT ON (f_validator_pubkey)
+			f_validator_pubkey,
+			f_depositor,
+			f_block_num,
+			'',
+			0
+		FROM %s
+		ORDER BY f_validator_pubkey, f_block_num DESC
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_depositor = EXCLUDED.f_depositor,
+			f_depositor_block = EXCLUDED.f_depositor_block
+		WHERE t_validator_last_deposit.f_depositor_block <= EXCLUDED.f_depositor_block;
+	`
+
+	upsertLastWithdrawalQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT DISTINCT ON (f_validator_pubkey)
+			f_validator_pubkey,
+			f_depositor,
+			f_block_num,
+			f_withdrawal_address,
+			f_block_num
+		FROM %s
+		WHERE f_withdrawal_address != ''
+		ORDER BY f_validator_pubkey, f_block_num DESC
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_withdrawal_address = EXCLUDED.f_withdrawal_address,
+			f_withdrawal_block = EXCLUDED.f_withdrawal_block
+		WHERE t_validator_last_deposit.f_withdrawal_block <= EXCLUDED.f_withdrawal_block;
+	`
+
+	// Mirrors the backfill in migration 000011.
+	rebuildValidatorLastDepositQuery = `
+		INSERT INTO t_validator_last_deposit (
+			f_validator_pubkey,
+			f_depositor,
+			f_depositor_block,
+			f_withdrawal_address,
+			f_withdrawal_block
+		)
+		SELECT
+			ld.f_validator_pubkey,
+			ld.f_depositor,
+			ld.f_block_num,
+			COALESCE(lw.f_withdrawal_address, ''),
+			COALESCE(lw.f_block_num, 0)
+		FROM (
+			SELECT DISTINCT ON (f_validator_pubkey)
+				f_validator_pubkey,
+				f_depositor,
+				f_block_num
+			FROM t_beacon_deposits
+			ORDER BY f_validator_pubkey, f_block_num DESC
+		) ld
+		LEFT JOIN (
+			SELECT DISTINCT ON (f_validator_pubkey)
+				f_validator_pubkey,
+				f_withdrawal_address,
+				f_block_num
+			FROM t_beacon_deposits
+			WHERE f_withdrawal_address != ''
+			ORDER BY f_validator_pubkey, f_block_num DESC
+		) lw ON ld.f_validator_pubkey = lw.f_validator_pubkey;
+	`
+)
+
+// upsertValidatorLastDeposit refreshes t_validator_last_deposit from a batch
+// of freshly downloaded deposits sitting in tempTableName. It must run inside
+// the same transaction that inserts the batch into t_beacon_deposits so the
+// two tables never drift apart.
+func (p *PostgresDBService) upsertValidatorLastDeposit(tx pgx.Tx, tempTableName string) error {
+	_, err := tx.Exec(p.ctx, fmt.Sprintf(upsertLastDepositorQuery, tempTableName))
+	if err != nil {
+		return errors.Wrap(err, "error upserting last depositor per validator")
+	}
+
+	_, err = tx.Exec(p.ctx, fmt.Sprintf(upsertLastWithdrawalQuery, tempTableName))
+	if err != nil {
+		return errors.Wrap(err, "error upserting last withdrawal address per validator")
+	}
+
+	return nil
+}
+
+// RebuildValidatorLastDeposit rebuilds t_validator_last_deposit from scratch
+// out of t_beacon_deposits. Meant for the periodic full rebuild (identify with
+// --recreate-table), as a safety valve against any drift.
+func (p *PostgresDBService) RebuildValidatorLastDeposit() error {
+	p.writerThreadsWG.Add(1)
+	defer p.writerThreadsWG.Done()
+	startTime := time.Now()
+
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return errors.Wrap(err, "error acquiring connection")
+	}
+	defer conn.Release()
+
+	tx, err := conn.Begin(p.ctx)
+	if err != nil {
+		return errors.Wrap(err, "error beginning rebuild transaction")
+	}
+	defer tx.Rollback(p.ctx)
+
+	_, err = tx.Exec(p.ctx, `TRUNCATE TABLE t_validator_last_deposit;`)
+	if err != nil {
+		return errors.Wrap(err, "error truncating t_validator_last_deposit")
+	}
+
+	_, err = tx.Exec(p.ctx, rebuildValidatorLastDepositQuery)
+	if err != nil {
+		return errors.Wrap(err, "error rebuilding t_validator_last_deposit")
+	}
+
+	if err := tx.Commit(p.ctx); err != nil {
+		return errors.Wrap(err, "error committing rebuild transaction")
+	}
+
+	_, err = conn.Exec(p.ctx, `ANALYZE t_validator_last_deposit;`)
+	if err != nil {
+		return errors.Wrap(err, "error analyzing t_validator_last_deposit")
+	}
+
+	wlog.Infof("rebuilt t_validator_last_deposit in %.2f seconds", time.Since(startTime).Seconds())
+	return nil
+}

--- a/db/validators_insert.go
+++ b/db/validators_insert.go
@@ -13,7 +13,8 @@ const (
 		f_pool_name
 	FROM
 		t_validators_insert
-	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name;
+	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name
+	WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -25,8 +25,9 @@ const (
 		INNER JOIN t_withdrawal_address_insert t2
 			ON t1.f_withdrawal_address = t2.f_withdrawal_address
 		WHERE t1.rn = 1
-		ON CONFLICT (f_validator_pubkey) DO UPDATE SET 
-			f_pool_name = EXCLUDED.f_pool_name;
+		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
+			f_pool_name = EXCLUDED.f_pool_name
+		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
 )
 

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -14,7 +14,11 @@ const (
 		FROM t_validator_last_deposit v
 		INNER JOIN t_withdrawal_address_insert m
 			ON v.f_withdrawal_address = m.f_withdrawal_address
+		LEFT JOIN t_identified_validators t
+			ON t.f_validator_pubkey = v.f_validator_pubkey
 		WHERE v.f_withdrawal_address != ''
+			AND (t.f_validator_pubkey IS NULL
+				OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -19,6 +19,15 @@ const (
 		WHERE v.f_withdrawal_address != ''
 			AND (t.f_validator_pubkey IS NULL
 				OR t.f_pool_name IS DISTINCT FROM m.f_pool_name)
+			-- Skip validators that a later phase claims (see issue #28): it
+			-- would overwrite the tag again in the same run.
+			AND t.f_pool_name IS DISTINCT FROM 'coinbase'
+			AND NOT EXISTS (SELECT 1 FROM t_rocketpool r
+				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_lido l
+				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -8,23 +8,13 @@ const (
 			f_validator_pubkey,
 			f_pool_name
 		)
-		SELECT DISTINCT 
-			t1.f_validator_pubkey, 
-			t2.f_pool_name 
-		FROM (
-			SELECT 
-				f_validator_pubkey,
-				f_withdrawal_address,
-				ROW_NUMBER() OVER (
-					PARTITION BY f_validator_pubkey 
-					ORDER BY f_block_num DESC
-				) as rn
-			FROM t_beacon_deposits
-			WHERE f_withdrawal_address!=''
-		) t1
-		INNER JOIN t_withdrawal_address_insert t2
-			ON t1.f_withdrawal_address = t2.f_withdrawal_address
-		WHERE t1.rn = 1
+		SELECT
+			v.f_validator_pubkey,
+			m.f_pool_name
+		FROM t_validator_last_deposit v
+		INNER JOIN t_withdrawal_address_insert m
+			ON v.f_withdrawal_address = m.f_withdrawal_address
+		WHERE v.f_withdrawal_address != ''
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ALCHEMY_URL=${ALCHEMY_URL}
       - WHALE_THRESHOLD=${WHALE_THRESHOLD}
       - ONLY_DEPOSITS=${ONLY_DEPOSITS:-false}
+      - RECREATE_TABLE=${RECREATE_TABLE:-false}
     network_mode: "host"
     depends_on:
       db:

--- a/identify/identify.go
+++ b/identify/identify.go
@@ -105,18 +105,12 @@ func (i *Identify) Run() {
 		}
 	}
 
-	if !i.stop {
-		startTime := time.Now()
-		log.Info("Applying withdrawal address insert")
-		err := i.dbClient.ApplyWithdrawalAddressInsert()
-		if err != nil {
-			log.Errorf("Error applying withdrawal address insert: %v. Skipping to next step.", err)
-		} else {
-			endTime := time.Now()
-			log.Infof("Applied withdrawal address insert in %v", endTime.Sub(startTime))
-		}
-	}
-
+	// Depositor tags (typically the node operator) are applied BEFORE
+	// withdrawal-address tags (the owner of the stake) on purpose: both
+	// upserts resolve conflicts positionally (last write wins), and a
+	// withdrawal credential is a stronger ownership signal than who sent
+	// the deposit transaction, since batch-deposit contracts are shared
+	// infrastructure. See issue #28.
 	if !i.stop {
 		startTime := time.Now()
 		log.Info("Applying depositors insert")
@@ -126,6 +120,18 @@ func (i *Identify) Run() {
 		} else {
 			endTime := time.Now()
 			log.Infof("Applied depositors insert in %v", endTime.Sub(startTime))
+		}
+	}
+
+	if !i.stop {
+		startTime := time.Now()
+		log.Info("Applying withdrawal address insert")
+		err := i.dbClient.ApplyWithdrawalAddressInsert()
+		if err != nil {
+			log.Errorf("Error applying withdrawal address insert: %v. Skipping to next step.", err)
+		} else {
+			endTime := time.Now()
+			log.Infof("Applied withdrawal address insert in %v", endTime.Sub(startTime))
 		}
 	}
 

--- a/identify/identify.go
+++ b/identify/identify.go
@@ -71,8 +71,15 @@ func (i *Identify) Run() {
 
 	if i.iConfig.RecreateTable && !i.stop {
 		startTime := time.Now()
+		// Full rebuilds also refresh t_validator_last_deposit from scratch, as
+		// a periodic safety valve against any drift in the incremental upserts.
+		log.Info("Rebuilding validator last deposit table")
+		err := i.dbClient.RebuildValidatorLastDeposit()
+		if err != nil {
+			log.Errorf("Error rebuilding validator last deposit table: %v. Skipping to next step.", err)
+		}
 		log.Info("Truncating identified validators table")
-		err := i.dbClient.TruncateIdentifiedValidators()
+		err = i.dbClient.TruncateIdentifiedValidators()
 		if err != nil {
 			log.Errorf("Error truncating identified validators table: %v. Skipping to next step.", err)
 		} else {

--- a/identify/lido.go
+++ b/identify/lido.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"sync"
+	"sync/atomic"
 
 	db "github.com/migalabs/eth-pokhar/db"
 	"github.com/migalabs/eth-pokhar/lido"
@@ -15,23 +16,61 @@ import (
 
 const maxBatchSize = 500
 
+// lidoModuleStats aggregates per-operator outcomes of a module pass.
+type lidoModuleStats struct {
+	skipped     atomic.Int64
+	incremental atomic.Int64
+	full        atomic.Int64
+}
+
+// lidoOperatorAction decides how to treat an operator by comparing the number
+// of keys already stored in t_lido against the on-chain total (which comes for
+// free with the operator data). Key registries are append-mostly, so most
+// operators need no work at all; fewer on-chain keys than stored means keys
+// were removed (the curated module compacts indexes on removal), which forces
+// a full refetch so the reconcile can drop fossils. Full runs (recreate-table)
+// force the full path for every operator: that weekly pass also absorbs
+// operator renames and any drift the incremental path cannot see.
+func (i *Identify) lidoOperatorAction(protocol string, operatorIndex uint64, onChainTotal uint64, keyCounts map[string]uint64, stats *lidoModuleStats) (string, uint64) {
+	if !i.iConfig.RecreateTable {
+		dbCount := keyCounts[db.LidoOperatorCountKey(protocol, operatorIndex)]
+		if dbCount == onChainTotal {
+			stats.skipped.Add(1)
+			return "skip", 0
+		}
+		if dbCount < onChainTotal {
+			stats.incremental.Add(1)
+			return "incremental", dbCount
+		}
+	}
+	stats.full.Add(1)
+	return "full", 0
+}
+
 func (i *Identify) IdentifyLidoValidators() error {
+	// One snapshot of stored key counts shared by the three modules. Operators
+	// are visited once per run, so intra-run staleness is not a concern.
+	keyCounts, err := i.dbClient.ObtainLidoOperatorKeyCounts()
+	if err != nil {
+		return err
+	}
+
 	log.Debug("Identifying lido curated module validators")
-	err := i.identifyCuratedModule()
+	err = i.identifyCuratedModule(keyCounts)
 	if err != nil {
 		return err
 	}
 	log.Debug("Identified lido curated module validators")
 
 	log.Debug("Identifying lido SDVT module validators")
-	err = i.identifySDVT()
+	err = i.identifySDVT(keyCounts)
 	if err != nil {
 		return err
 	}
 	log.Debug("Identified lido SDVT module validators")
 
 	log.Debug("Identifying lido csm validators")
-	err = i.identifyCSM()
+	err = i.identifyCSM(keyCounts)
 	if err != nil {
 		return err
 	}
@@ -43,10 +82,10 @@ func (i *Identify) IdentifyLidoValidators() error {
 ///// Simple DVT /////
 
 // identifySDVT identifies the validators for the Simple DVT module. Same key
-// registry semantics as the Curated module — only the contract address and
+// registry semantics as the Curated module: only the contract address and
 // operator name resolution differ. Operator names come from the on-chain
 // contract (no pre-defined override list).
-func (i *Identify) identifySDVT() error {
+func (i *Identify) identifySDVT(keyCounts map[string]uint64) error {
 	log.Debug("Creating a new instance of SDVT contract")
 	sdvtContract, err := sdvt.NewSDVTContract(i.iConfig.ElEndpoint)
 	if err != nil {
@@ -59,6 +98,7 @@ func (i *Identify) identifySDVT() error {
 	}
 	log.Debugf("Found %v SDVT operators", operatorsCount)
 
+	stats := &lidoModuleStats{}
 	workerSemaphore := make(chan struct{}, 10)
 	var wg sync.WaitGroup
 
@@ -66,27 +106,24 @@ func (i *Identify) identifySDVT() error {
 		if i.stop {
 			break
 		}
-		operator, err := sdvtContract.GetOperatorData(big.NewInt(operatorIndex))
-		if err != nil {
-			wg.Wait()
-			return err
-		}
 		wg.Add(1)
 		workerSemaphore <- struct{}{}
 
-		go func(operator curated.NodeOperator) {
+		go func(operatorIndex int64) {
 			defer wg.Done()
-			if err := i.processSDVTOperatorKeys(operator); err != nil {
-				log.Errorf("Error reconciling SDVT operator %v: %v", operator.Index, err)
+			if err := i.processSDVTOperatorKeys(operatorIndex, keyCounts, stats); err != nil {
+				log.Errorf("Error reconciling SDVT operator %v: %v", operatorIndex, err)
 			}
 			<-workerSemaphore
-		}(operator)
+		}(operatorIndex)
 	}
 
 	wg.Wait()
 	if i.stop {
 		return nil
 	}
+	log.Infof("SDVT module: operators=%d skipped=%d incremental=%d full=%d",
+		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
 	err = i.dbClient.IdentifyLidoValidators()
 	if err != nil {
@@ -95,18 +132,28 @@ func (i *Identify) identifySDVT() error {
 	return nil
 }
 
-func (i *Identify) processSDVTOperatorKeys(operator curated.NodeOperator) error {
+func (i *Identify) processSDVTOperatorKeys(operatorIndex int64, keyCounts map[string]uint64, stats *lidoModuleStats) error {
 	sdvtContract, err := sdvt.NewSDVTContract(i.iConfig.ElEndpoint)
+	if err != nil {
+		return err
+	}
+
+	operator, err := sdvtContract.GetOperatorData(big.NewInt(operatorIndex))
 	if err != nil {
 		return err
 	}
 
 	operatorName := sdvt.GetOperatorName(operator)
 	totalKeys := operator.TotalSigningKeys
-	log.Infof("Reconciling keys for SDVT operator %v (on-chain total=%v)", operatorName, totalKeys)
 
-	validatorPubkeys := make([]string, 0, totalKeys)
-	offset := uint64(0)
+	action, offset := i.lidoOperatorAction(db.LidoProtocolSDVT, operator.Index, totalKeys, keyCounts, stats)
+	if action == "skip" {
+		log.Debugf("SDVT operator %v: up to date (on-chain=%d)", operatorName, totalKeys)
+		return nil
+	}
+	log.Infof("Reconciling keys for SDVT operator %v (action=%s on-chain total=%v)", operatorName, action, totalKeys)
+
+	validatorPubkeys := make([]string, 0, totalKeys-offset)
 	for offset < totalKeys {
 		if i.stop {
 			return nil
@@ -127,6 +174,15 @@ func (i *Identify) processSDVTOperatorKeys(operator curated.NodeOperator) error 
 		offset += limit
 	}
 
+	if action == "incremental" {
+		upserted, err := i.dbClient.AppendLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolSDVT)
+		if err != nil {
+			return err
+		}
+		log.Infof("SDVT operator %v appended: on-chain=%d new=%d", operatorName, totalKeys, upserted)
+		return nil
+	}
+
 	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolSDVT)
 	if err != nil {
 		return err
@@ -137,7 +193,7 @@ func (i *Identify) processSDVTOperatorKeys(operator curated.NodeOperator) error 
 
 ///// CSM /////
 
-func (i *Identify) identifyCSM() error {
+func (i *Identify) identifyCSM(keyCounts map[string]uint64) error {
 	log.Debug("Creating a new instance of LidoContract")
 	csmContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
 	// Check if there was an error
@@ -153,6 +209,7 @@ func (i *Identify) identifyCSM() error {
 	log.Debugf("Found %v operators", operatorsCount)
 
 	log.Debug("Getting keys for each operator")
+	stats := &lidoModuleStats{}
 	workerSemaphore := make(chan struct{}, 10)
 	var wg sync.WaitGroup
 
@@ -160,22 +217,16 @@ func (i *Identify) identifyCSM() error {
 		if i.stop {
 			break
 		}
-		operator, err := csmContract.GetOperatorData(big.NewInt(operatorIndex))
-		if err != nil {
-			wg.Wait()
-			return err
-		}
 		wg.Add(1)
 		workerSemaphore <- struct{}{}
 
-		go func(operator csm.NodeOperatorCustom) {
+		go func(operatorIndex int64) {
 			defer wg.Done()
-			err := i.processCSMOperatorKeys(operator)
-			if err != nil {
-				log.Fatalf("Error processing operator keys: %v", err)
+			if err := i.processCSMOperatorKeys(operatorIndex, keyCounts, stats); err != nil {
+				log.Errorf("Error reconciling CSM operator %v: %v", operatorIndex, err)
 			}
 			<-workerSemaphore
-		}(operator)
+		}(operatorIndex)
 	}
 	log.Debug("Finished getting keys for each operator")
 
@@ -183,6 +234,8 @@ func (i *Identify) identifyCSM() error {
 	if i.stop {
 		return nil
 	}
+	log.Infof("CSM module: operators=%d skipped=%d incremental=%d full=%d",
+		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
 	log.Debug("Identifying lido curated validators")
 	err = i.dbClient.IdentifyLidoValidators()
@@ -194,24 +247,45 @@ func (i *Identify) identifyCSM() error {
 	return nil
 }
 
-func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom) error {
+func (i *Identify) processCSMOperatorKeys(operatorIndex int64, keyCounts map[string]uint64, stats *lidoModuleStats) error {
+	csmContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
+	if err != nil {
+		return err
+	}
+
+	operator, err := csmContract.GetOperatorData(big.NewInt(operatorIndex))
+	if err != nil {
+		return err
+	}
+
 	operatorName := csm.GetOperatorName(operator)
 	totalKeys := uint64(operator.Operator.TotalDepositedKeys)
-	log.Infof("Reconciling keys for CSM operator %v (on-chain total=%v)", operatorName, totalKeys)
 
-	keysString := make([]string, 0, totalKeys)
-	if totalKeys > 0 {
-		lidoContract, err := csm.NewCSMContract(i.iConfig.ElEndpoint)
-		if err != nil {
-			return err
-		}
-		keys, err := lidoContract.GetOperatorKeys(operator, 0, totalKeys)
+	action, offset := i.lidoOperatorAction(db.LidoProtocolCSM, operator.Index, totalKeys, keyCounts, stats)
+	if action == "skip" {
+		log.Debugf("CSM operator %v: up to date (on-chain=%d)", operatorName, totalKeys)
+		return nil
+	}
+	log.Infof("Reconciling keys for CSM operator %v (action=%s on-chain total=%v)", operatorName, action, totalKeys)
+
+	keysString := make([]string, 0, totalKeys-offset)
+	if totalKeys > offset {
+		keys, err := csmContract.GetOperatorKeys(operator, offset, totalKeys-offset)
 		if err != nil {
 			return err
 		}
 		for _, key := range keys {
 			keysString = append(keysString, hex.EncodeToString(key))
 		}
+	}
+
+	if action == "incremental" {
+		upserted, err := i.dbClient.AppendLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
+		if err != nil {
+			return err
+		}
+		log.Infof("CSM operator %v appended: on-chain=%d new=%d", operatorName, totalKeys, upserted)
+		return nil
 	}
 
 	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, keysString, db.LidoProtocolCSM)
@@ -225,7 +299,7 @@ func (i *Identify) processCSMOperatorKeys(operator csm.NodeOperatorCustom) error
 ////// Curated Module //////
 
 // identifyCuratedModule identifies the validators for the curated module and adds them to the lido table
-func (i *Identify) identifyCuratedModule() error {
+func (i *Identify) identifyCuratedModule(keyCounts map[string]uint64) error {
 	log.Debug("Creating a new instance of LidoContract")
 	lidoContract, err := curated.NewCuratedModuleContract(i.iConfig.ElEndpoint)
 	// Check if there was an error
@@ -242,6 +316,7 @@ func (i *Identify) identifyCuratedModule() error {
 	log.Debugf("Found %v operators", operatorsCount)
 
 	log.Debug("Getting keys for each operator")
+	stats := &lidoModuleStats{}
 	workerSemaphore := make(chan struct{}, 10)
 	var wg sync.WaitGroup
 
@@ -249,21 +324,16 @@ func (i *Identify) identifyCuratedModule() error {
 		if i.stop {
 			break
 		}
-		operator, err := lidoContract.GetOperatorData(big.NewInt(operatorIndex))
-		if err != nil {
-			wg.Wait()
-			return err
-		}
 		wg.Add(1)
 		workerSemaphore <- struct{}{}
 
-		go func(operator curated.NodeOperator) {
+		go func(operatorIndex int64) {
 			defer wg.Done()
-			if err := i.processCuratedOperatorKeys(operator); err != nil {
-				log.Errorf("Error reconciling curated operator %v: %v", operator.Index, err)
+			if err := i.processCuratedOperatorKeys(operatorIndex, keyCounts, stats); err != nil {
+				log.Errorf("Error reconciling curated operator %v: %v", operatorIndex, err)
 			}
 			<-workerSemaphore
-		}(operator)
+		}(operatorIndex)
 	}
 	log.Debug("Finished getting keys for each operator")
 
@@ -271,6 +341,8 @@ func (i *Identify) identifyCuratedModule() error {
 	if i.stop {
 		return nil
 	}
+	log.Infof("Curated module: operators=%d skipped=%d incremental=%d full=%d",
+		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
 	log.Debug("Identifying lido curated validators")
 	err = i.dbClient.IdentifyLidoValidators()
@@ -282,18 +354,28 @@ func (i *Identify) identifyCuratedModule() error {
 	return nil
 }
 
-func (i *Identify) processCuratedOperatorKeys(operator curated.NodeOperator) error {
+func (i *Identify) processCuratedOperatorKeys(operatorIndex int64, keyCounts map[string]uint64, stats *lidoModuleStats) error {
 	lidoContract, err := curated.NewCuratedModuleContract(i.iConfig.ElEndpoint)
+	if err != nil {
+		return err
+	}
+
+	operator, err := lidoContract.GetOperatorData(big.NewInt(operatorIndex))
 	if err != nil {
 		return err
 	}
 
 	operatorName := curated.GetOperatorName(operator)
 	totalKeys := operator.TotalSigningKeys
-	log.Infof("Reconciling keys for curated operator %v (on-chain total=%v)", operatorName, totalKeys)
 
-	validatorPubkeys := make([]string, 0, totalKeys)
-	offset := uint64(0)
+	action, offset := i.lidoOperatorAction(db.LidoProtocolCurated, operator.Index, totalKeys, keyCounts, stats)
+	if action == "skip" {
+		log.Debugf("Curated operator %v: up to date (on-chain=%d)", operatorName, totalKeys)
+		return nil
+	}
+	log.Infof("Reconciling keys for curated operator %v (action=%s on-chain total=%v)", operatorName, action, totalKeys)
+
+	validatorPubkeys := make([]string, 0, totalKeys-offset)
 	for offset < totalKeys {
 		if i.stop {
 			return nil
@@ -312,6 +394,15 @@ func (i *Identify) processCuratedOperatorKeys(operator curated.NodeOperator) err
 			validatorPubkeys = append(validatorPubkeys, hex.EncodeToString(key))
 		}
 		offset += limit
+	}
+
+	if action == "incremental" {
+		upserted, err := i.dbClient.AppendLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)
+		if err != nil {
+			return err
+		}
+		log.Infof("Curated operator %v appended: on-chain=%d new=%d", operatorName, totalKeys, upserted)
+		return nil
 	}
 
 	upserted, removed, err := i.dbClient.ReconcileLidoOperatorValidators(operatorName, operator.Index, validatorPubkeys, db.LidoProtocolCurated)

--- a/identify/lido.go
+++ b/identify/lido.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	db "github.com/migalabs/eth-pokhar/db"
 	"github.com/migalabs/eth-pokhar/lido"
@@ -76,6 +77,16 @@ func (i *Identify) IdentifyLidoValidators() error {
 	}
 	log.Debug("Identified lido csm validators")
 
+	// One single pass over t_lido after the three modules updated it: the
+	// UPDATE joins half a million keys against t_identified_validators, so
+	// running it per module tripled the cost for the same final state.
+	startTime := time.Now()
+	err = i.dbClient.IdentifyLidoValidators()
+	if err != nil {
+		return err
+	}
+	log.Infof("Applied lido pool names in %v", time.Since(startTime))
+
 	return nil
 }
 
@@ -125,10 +136,6 @@ func (i *Identify) identifySDVT(keyCounts map[string]uint64) error {
 	log.Infof("SDVT module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -237,13 +244,6 @@ func (i *Identify) identifyCSM(keyCounts map[string]uint64) error {
 	log.Infof("CSM module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
 
-	log.Debug("Identifying lido curated validators")
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
-	log.Debug("Identified lido validators")
-
 	return nil
 }
 
@@ -343,13 +343,6 @@ func (i *Identify) identifyCuratedModule(keyCounts map[string]uint64) error {
 	}
 	log.Infof("Curated module: operators=%d skipped=%d incremental=%d full=%d",
 		operatorsCount, stats.skipped.Load(), stats.incremental.Load(), stats.full.Load())
-
-	log.Debug("Identifying lido curated validators")
-	err = i.dbClient.IdentifyLidoValidators()
-	if err != nil {
-		return err
-	}
-	log.Debug("Identified lido validators")
 
 	return nil
 }

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,12 @@ else
     ./eth_pokhar beacon_depositors_transactions --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} || exit 1
 fi
 
-./eth_pokhar identify --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} --recreate-table --whale-threshold=${WHALE_THRESHOLD} || exit 1
+# RECREATE_TABLE=true truncates t_identified_validators and rebuilds it from
+# scratch. Meant for methodology changes or a periodic (e.g. weekly) full
+# rebuild; daily runs should be incremental (default).
+RECREATE_FLAG=""
+if [ "${RECREATE_TABLE:-false}" = "true" ]; then
+    RECREATE_FLAG="--recreate-table"
+fi
+
+./eth_pokhar identify --log-level=${LOG_LEVEL} --el-endpoint=${EL_ENDPOINT} --db-url=${DB_URL} --workers-num=${WORKER_NUM} --alchemy-url=${ALCHEMY_URL} ${RECREATE_FLAG} --whale-threshold=${WHALE_THRESHOLD} || exit 1

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -54,7 +54,23 @@ export SYNC_TUNNEL_TARGET=localhost:5439     # Postgres as seen from the ssh hos
 export SYNC_TUNNEL_WAIT_SECS=20
 ```
 
+### Credentials handling
+
+Secrets never travel on a command line, where any local user can read them in `/proc/<pid>/cmdline` for the duration of the call:
+
+- The ClickHouse password is passed through the `CLICKHOUSE_PASSWORD` environment variable (honored by clickhouse-client). Docker-based `CH_CLIENT` values must forward it without a value so it never hits a command line either: `CH_CLIENT="docker exec -i -e CLICKHOUSE_PASSWORD my-clickhouse clickhouse-client"`.
+- Queries go through stdin instead of `--query`, which also keeps the Postgres credentials embedded in the `postgresql()` table function calls off the process list. ClickHouse masks table function secrets in `system.query_log`; defining a server-side named collection for the labels Postgres removes them from the query text entirely if you want the extra belt.
+- The env file remains the at-rest copy of the secrets: keep it readable only by the cron user.
+
+### Concurrency
+
+The script takes a non-blocking `flock` on `SYNC_LOCK_FILE` (default `/tmp/labels-sync-<db>-<port>.lock`) and aborts with a non-zero status if another run against the same target is still going. Overlapping runs would race on the same staging table, and a double `EXCHANGE TABLES` could silently re-apply a stale mapping with both runs reporting success. A skipped run raises the exit-status metric, which is the correct signal: the interesting event is the previous run still holding the lock.
+
+### On-call note: failures after the swap
+
+Every failure before `EXCHANGE TABLES` leaves the live mapping untouched: rerunning is always safe. Failures AFTER the swap (mirror sync, version stamping) exit non-zero for alerting but the new mapping is already live; the log prints an explicit warning in that case. Do not "roll back" on the basis of the exit code alone: rollback is only ever the manual `EXCHANGE TABLES`, and only if the applied snapshot itself is the problem.
+
 ### Recommended alerts
 
 - `time() - cron_job_last_run_timestamp_seconds{cron_name="..."} > 2 * <sync period>`: the sync stopped running (this once went unnoticed for two months).
-- `cron_job_last_run_exit_status{cron_name="..."} != 0`: the last snapshot was rejected by a gate or the import failed.
+- `cron_job_last_run_exit_status{cron_name="..."} != 0`: the last snapshot was rejected by a gate, the import failed, a concurrent run was skipped, or a post-swap step failed (see the on-call note).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,40 @@
+# Scripts
+
+## sync-labels-to-clickhouse.sh
+
+Distributes the labels produced by the identify pipeline (Postgres `t_identified_validators`) to a goteth ClickHouse database (`t_eth2_pubkeys`). Replaces the legacy per-machine TRUNCATE + INSERT scripts with the design from issue #31:
+
+- **Atomic**: imports into `t_eth2_pubkeys_staging`, applies with `EXCHANGE TABLES`. Consumers never observe an empty or partial mapping. After a successful run the staging table holds the previous mapping, so rollback is one more `EXCHANGE TABLES`.
+- **Versioned**: each applied snapshot inserts a row into `t_eth2_pubkeys_version` (query with `FINAL`, it keeps the highest `f_version`). Consumers such as the goteth pool summary reroll can log exactly which labels version they operate on.
+- **Gated**: the snapshot is rejected, keeping the previous mapping, if it is empty, if it shrinks below `SYNC_MIN_COUNT_RATIO` of the previous count, or if any existing pool loses more than `SYNC_MAX_POOL_DROP` validators. Legitimate renames or splits are declared in the allowlist file (`SYNC_POOL_RENAME_ALLOWLIST`, one pool name per line) for the run where they happen.
+- **Monitored**: with `TEXTFILE_DIR` set, exports `cron_job_last_run_timestamp_seconds`, `cron_job_last_run_time_taken_milliseconds` and `cron_job_last_run_exit_status` for node_exporter's textfile collector.
+
+### Example
+
+```bash
+# /etc/cron.d style, every 6 hours. Keep the env file readable only by the cron user.
+0 */6 * * *  . /path/to/labels-sync.env && /path/to/scripts/sync-labels-to-clickhouse.sh >> /var/log/labels-sync.log 2>&1
+```
+
+```bash
+# labels-sync.env
+export PG_HOST=<postgres host as reachable from the ClickHouse SERVER process>
+export PG_PORT=5439
+export PG_DB=eth_pokhar
+export PG_USER=...
+export PG_PASS=...
+export CH_CLIENT="docker exec -i my-clickhouse-container clickhouse-client"
+export CH_PORT=9000
+export CH_USER=...
+export CH_PASS=...
+export CH_DB=goteth
+export TEXTFILE_DIR=/path/to/node_exporter/textfiles
+export CRON_NAME=labels_sync_mainnet
+```
+
+Note: the import runs server-side via the `postgresql()` table function, so `PG_HOST:PG_PORT` must be reachable from the ClickHouse **server**, not from the shell running the script. If the Postgres is remote, open the tunnel before invoking the script and bind it on an address the server can reach.
+
+### Recommended alerts
+
+- `time() - cron_job_last_run_timestamp_seconds{cron_name="..."} > 2 * <sync period>`: the sync stopped running (this once went unnoticed for two months).
+- `cron_job_last_run_exit_status{cron_name="..."} != 0`: the last snapshot was rejected by a gate or the import failed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@ Distributes the labels produced by the identify pipeline (Postgres `t_identified
 - **Gated**: the snapshot is rejected, keeping the previous mapping, if it is empty, if it shrinks below `SYNC_MIN_COUNT_RATIO` of the previous count, or if any existing pool loses more than `SYNC_MAX_POOL_DROP` validators. Legitimate renames or splits are declared in the allowlist file (`SYNC_POOL_RENAME_ALLOWLIST`, one pool name per line) for the run where they happen.
 - **Monitored**: with `TEXTFILE_DIR` set, exports `cron_job_last_run_timestamp_seconds`, `cron_job_last_run_time_taken_milliseconds` and `cron_job_last_run_exit_status` for node_exporter's textfile collector.
 - **Optional mirror**: with `SYNC_PUBKEY_POOL=true`, also refreshes the `t_pubkey_pool` mirror (pubkey to pool without a val_idx, used to label deposits still in the pending queue) with the same staging plus `EXCHANGE TABLES` pattern. Enable it only on deployments that have that table.
+- **Single source read**: Postgres is read exactly once per run into `t_labels_snapshot`, and both the main mapping and the mirror are derived from it. All distributed tables therefore reflect the same instant of the source and are covered by the same gates; there is no window for cross-table drift between them.
 
 ### Example
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,6 +55,8 @@ export SYNC_TUNNEL_TARGET=localhost:5439     # Postgres as seen from the ssh hos
 export SYNC_TUNNEL_WAIT_SECS=20
 ```
 
+Mind the bind address: the import runs inside the ClickHouse **server**, so the tunnel must listen where that server can reach it. The default `127.0.0.1` only works when ClickHouse runs directly on the launcher's host (or with `--network=host`); a bridge-networked ClickHouse container has its own isolated loopback and will never reach the host's `127.0.0.1`, even though the launcher's health check passes. For that layout bind on `0.0.0.0` or the docker bridge IP, and set `PG_HOST` accordingly (e.g. the bridge gateway).
+
 ### Credentials handling
 
 Secrets never travel on a command line, where any local user can read them in `/proc/<pid>/cmdline` for the duration of the call:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,7 @@ Distributes the labels produced by the identify pipeline (Postgres `t_identified
 - **Versioned**: each applied snapshot inserts a row into `t_eth2_pubkeys_version` (query with `FINAL`, it keeps the highest `f_version`). Consumers such as the goteth pool summary reroll can log exactly which labels version they operate on.
 - **Gated**: the snapshot is rejected, keeping the previous mapping, if it is empty, if it shrinks below `SYNC_MIN_COUNT_RATIO` of the previous count, or if any existing pool loses more than `SYNC_MAX_POOL_DROP` validators. Legitimate renames or splits are declared in the allowlist file (`SYNC_POOL_RENAME_ALLOWLIST`, one pool name per line) for the run where they happen.
 - **Monitored**: with `TEXTFILE_DIR` set, exports `cron_job_last_run_timestamp_seconds`, `cron_job_last_run_time_taken_milliseconds` and `cron_job_last_run_exit_status` for node_exporter's textfile collector.
+- **Optional mirror**: with `SYNC_PUBKEY_POOL=true`, also refreshes the `t_pubkey_pool` mirror (pubkey to pool without a val_idx, used to label deposits still in the pending queue) with the same staging plus `EXCHANGE TABLES` pattern. Enable it only on deployments that have that table.
 
 ### Example
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,7 +33,26 @@ export TEXTFILE_DIR=/path/to/node_exporter/textfiles
 export CRON_NAME=labels_sync_mainnet
 ```
 
-Note: the import runs server-side via the `postgresql()` table function, so `PG_HOST:PG_PORT` must be reachable from the ClickHouse **server**, not from the shell running the script. If the Postgres is remote, open the tunnel before invoking the script and bind it on an address the server can reach.
+Note: the import runs server-side via the `postgresql()` table function, so `PG_HOST:PG_PORT` must be reachable from the ClickHouse **server**, not from the shell running the script. If the Postgres is remote, open the tunnel before invoking the script and bind it on an address the server can reach, or use the launcher below which handles that.
+
+## run-labels-sync.sh
+
+Launcher meant to be the cron entry point. It sources a local env file (argument, or `labels-sync.env` next to the script by default), optionally opens an SSH tunnel to the labels Postgres, waits until the tunnel actually accepts connections, and runs `sync-labels-to-clickhouse.sh` with a cleanup trap that closes the tunnel on exit. Keeps every deployment on the same reviewed logic: the only thing that lives outside the repo is the env file with credentials and endpoints.
+
+```bash
+# crontab, every 6 hours
+0 */6 * * * /path/to/scripts/run-labels-sync.sh /path/to/labels-sync.env >> /var/log/labels-sync.log 2>&1
+```
+
+Tunnel variables, all optional, set in the env file:
+
+```bash
+export SYNC_TUNNEL_SSH_HOST=labels-db-host   # unset: no tunnel, PG_HOST used as-is
+export SYNC_TUNNEL_BIND=0.0.0.0              # bind on an address the ClickHouse server reaches
+export SYNC_TUNNEL_PORT=15440
+export SYNC_TUNNEL_TARGET=localhost:5439     # Postgres as seen from the ssh host
+export SYNC_TUNNEL_WAIT_SECS=20
+```
 
 ### Recommended alerts
 

--- a/scripts/run-labels-sync.sh
+++ b/scripts/run-labels-sync.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Launcher for sync-labels-to-clickhouse.sh: loads a local env file, optionally
+# opens an SSH tunnel to the labels Postgres, and runs the sync engine.
+#
+# Usage:
+#   run-labels-sync.sh [/path/to/labels-sync.env]
+#
+# The env file defaults to labels-sync.env next to this script. It must define
+# the engine variables (PG_*, CH_*, SYNC_*, TEXTFILE_DIR, CRON_NAME; see
+# README.md) and may define the tunnel variables:
+#
+#   SYNC_TUNNEL_SSH_HOST   ssh host (alias or user@host) that can reach the
+#                          labels Postgres. Empty or unset: no tunnel is
+#                          opened and PG_HOST/PG_PORT are used as-is.
+#   SYNC_TUNNEL_BIND       local address to bind (default 127.0.0.1)
+#   SYNC_TUNNEL_PORT       local port to bind (default 15440)
+#   SYNC_TUNNEL_TARGET     host:port of Postgres as seen from the ssh host
+#                          (default localhost:5432)
+#   SYNC_TUNNEL_WAIT_SECS  max seconds to wait for the tunnel (default 20)
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="${1:-$DIR/labels-sync.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "[labels-sync-wrapper] ERROR: env file not found: $ENV_FILE"
+    exit 1
+fi
+
+set -a
+. "$ENV_FILE"
+set +a
+
+SYNC_TUNNEL_SSH_HOST="${SYNC_TUNNEL_SSH_HOST:-}"
+SYNC_TUNNEL_BIND="${SYNC_TUNNEL_BIND:-127.0.0.1}"
+SYNC_TUNNEL_PORT="${SYNC_TUNNEL_PORT:-15440}"
+SYNC_TUNNEL_TARGET="${SYNC_TUNNEL_TARGET:-localhost:5432}"
+SYNC_TUNNEL_WAIT_SECS="${SYNC_TUNNEL_WAIT_SECS:-20}"
+
+if [ -n "$SYNC_TUNNEL_SSH_HOST" ]; then
+    ssh -N -L "${SYNC_TUNNEL_BIND}:${SYNC_TUNNEL_PORT}:${SYNC_TUNNEL_TARGET}" "$SYNC_TUNNEL_SSH_HOST" &
+    TUNNEL_PID=$!
+    trap 'kill $TUNNEL_PID 2>/dev/null || true; wait $TUNNEL_PID 2>/dev/null || true' EXIT
+
+    # 0.0.0.0 is not connectable as a destination, probe via loopback instead
+    CHECK_HOST="$SYNC_TUNNEL_BIND"
+    [ "$CHECK_HOST" = "0.0.0.0" ] && CHECK_HOST=127.0.0.1
+
+    waited=0
+    until timeout 2 bash -c "echo > /dev/tcp/${CHECK_HOST}/${SYNC_TUNNEL_PORT}" 2>/dev/null; do
+        if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+            echo "[labels-sync-wrapper] ERROR: ssh tunnel process died"
+            exit 1
+        fi
+        waited=$((waited + 1))
+        if [ "$waited" -ge "$SYNC_TUNNEL_WAIT_SECS" ]; then
+            echo "[labels-sync-wrapper] ERROR: tunnel not reachable at ${CHECK_HOST}:${SYNC_TUNNEL_PORT} after ${SYNC_TUNNEL_WAIT_SECS}s"
+            exit 1
+        fi
+        sleep 1
+    done
+fi
+
+exec_status=0
+bash "${SYNC_ENGINE_PATH:-$DIR/sync-labels-to-clickhouse.sh}" || exec_status=$?
+exit $exec_status

--- a/scripts/run-labels-sync.sh
+++ b/scripts/run-labels-sync.sh
@@ -12,7 +12,12 @@
 #   SYNC_TUNNEL_SSH_HOST   ssh host (alias or user@host) that can reach the
 #                          labels Postgres. Empty or unset: no tunnel is
 #                          opened and PG_HOST/PG_PORT are used as-is.
-#   SYNC_TUNNEL_BIND       local address to bind (default 127.0.0.1)
+#   SYNC_TUNNEL_BIND       local address to bind (default 127.0.0.1). The
+#                          postgresql() import runs inside the ClickHouse
+#                          SERVER: if that server is a bridge-networked
+#                          container, its loopback is isolated from the host
+#                          and cannot reach 127.0.0.1, so set 0.0.0.0 or the
+#                          docker bridge IP the server can actually reach.
 #   SYNC_TUNNEL_PORT       local port to bind (default 15440)
 #   SYNC_TUNNEL_TARGET     host:port of Postgres as seen from the ssh host
 #                          (default localhost:5432)

--- a/scripts/sync-labels-to-clickhouse.sh
+++ b/scripts/sync-labels-to-clickhouse.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+#
+# sync-labels-to-clickhouse.sh
+#
+# Distributes the validator -> pool labels produced by eth-pokhar (Postgres,
+# t_identified_validators) to a goteth ClickHouse database (t_eth2_pubkeys),
+# implementing the design of issue #31:
+#
+#   1. Atomic apply: the snapshot is imported into t_eth2_pubkeys_staging and
+#      applied with EXCHANGE TABLES, so consumers always see either the old or
+#      the new complete mapping, never an empty or partial one.
+#   2. Versioned: every applied snapshot writes a row to t_eth2_pubkeys_version
+#      (ReplacingMergeTree keyed on a single row, query it with FINAL).
+#   3. Gated: the snapshot is rejected (keeping the previous mapping) if it
+#      shrinks more than SYNC_MIN_COUNT_RATIO allows, or if any existing pool
+#      loses more than SYNC_MAX_POOL_DROP validators and is not listed in the
+#      rename allowlist.
+#   4. Monitored: optionally exports cron_job_* metrics for node_exporter's
+#      textfile collector. Alert on cron_job_last_run_timestamp_seconds age.
+#
+# After a successful run, t_eth2_pubkeys_staging holds the PREVIOUS mapping.
+# Rollback = running EXCHANGE TABLES again by hand.
+#
+# Configuration (environment variables, e.g. from a protected .env file):
+#
+#   PG_HOST / PG_PORT / PG_DB / PG_USER / PG_PASS
+#       Labels Postgres, as reachable FROM the ClickHouse server process
+#       (the import uses the postgresql() table function server-side).
+#   CH_CLIENT      command used to reach ClickHouse (default: clickhouse-client)
+#   CH_PORT        native port (default: 9000)
+#   CH_USER / CH_PASS / CH_DB
+#   SYNC_MIN_COUNT_RATIO       minimum new/old row ratio (default: 0.95)
+#   SYNC_MAX_POOL_DROP         max validators an existing pool may lose
+#                              (default: 5000, 0 disables the gate)
+#   SYNC_POOL_RENAME_ALLOWLIST optional file with one pool name per line,
+#                              exempt from the pool-drop gate (renames/splits)
+#   TEXTFILE_DIR               optional node_exporter textfile directory
+#   CRON_NAME                  metric label (default: labels_sync)
+#
+set -u
+
+LOG_PREFIX="[labels-sync]"
+PG_HOST="${PG_HOST:?PG_HOST is required}"
+PG_PORT="${PG_PORT:?PG_PORT is required}"
+PG_DB="${PG_DB:?PG_DB is required}"
+PG_USER="${PG_USER:?PG_USER is required}"
+PG_PASS="${PG_PASS:?PG_PASS is required}"
+CH_CLIENT="${CH_CLIENT:-clickhouse-client}"
+CH_PORT="${CH_PORT:-9000}"
+CH_USER="${CH_USER:-default}"
+CH_PASS="${CH_PASS:-}"
+CH_DB="${CH_DB:?CH_DB is required}"
+SYNC_MIN_COUNT_RATIO="${SYNC_MIN_COUNT_RATIO:-0.95}"
+SYNC_MAX_POOL_DROP="${SYNC_MAX_POOL_DROP:-5000}"
+SYNC_POOL_RENAME_ALLOWLIST="${SYNC_POOL_RENAME_ALLOWLIST:-}"
+TEXTFILE_DIR="${TEXTFILE_DIR:-}"
+CRON_NAME="${CRON_NAME:-labels_sync}"
+
+status=1
+start=$(date +%s%3N)
+TMPDIR_SYNC=$(mktemp -d)
+
+cleanup() {
+    end=$(date +%s%3N)
+    runtime=$((end - start))
+    rm -rf "$TMPDIR_SYNC"
+    if [ -n "$TEXTFILE_DIR" ]; then
+        prom="$TEXTFILE_DIR/${CRON_NAME}.prom"
+        {
+            echo "cron_job_last_run_timestamp_seconds{cron_name=\"${CRON_NAME}\"} $(date +%s)"
+            echo "cron_job_last_run_time_taken_milliseconds{cron_name=\"${CRON_NAME}\"} ${runtime}"
+            echo "cron_job_last_run_exit_status{cron_name=\"${CRON_NAME}\"} ${status}"
+        } > "${prom}.$$" && mv "${prom}.$$" "${prom}"
+    fi
+    echo "$LOG_PREFIX $(date -u +%FT%TZ) Finished with status=$status in ${runtime}ms"
+}
+trap cleanup EXIT
+
+ch() {
+    $CH_CLIENT --port "$CH_PORT" --user "$CH_USER" --password "$CH_PASS" --database "$CH_DB" --query "$1"
+}
+
+echo "$LOG_PREFIX $(date -u +%FT%TZ) Starting labels sync..."
+
+# ---------------------------------------------------------------- previous state
+PREV_COUNT=$(ch "SELECT count() FROM t_eth2_pubkeys") || exit 1
+echo "$LOG_PREFIX Previous mapping: $PREV_COUNT entries"
+
+if [ "$PREV_COUNT" -gt 0 ] && [ "$SYNC_MAX_POOL_DROP" -gt 0 ]; then
+    ch "SELECT f_pool_name, count() FROM t_eth2_pubkeys FINAL GROUP BY f_pool_name FORMAT TSV" \
+        > "$TMPDIR_SYNC/pools_prev.tsv" || exit 1
+fi
+
+# ---------------------------------------------------------------- import to staging
+ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_staging AS t_eth2_pubkeys" || exit 1
+ch "TRUNCATE TABLE t_eth2_pubkeys_staging" || exit 1
+
+echo "$LOG_PREFIX Importing snapshot into t_eth2_pubkeys_staging..."
+ch "
+    INSERT INTO t_eth2_pubkeys_staging (f_val_idx, f_public_key, f_pool_name, f_pool)
+    SELECT
+        vls.f_val_idx,
+        vls.f_public_key,
+        iv.f_pool_name,
+        iv.f_pool_name AS f_pool
+    FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
+    INNER JOIN t_validator_last_status AS vls
+        ON concat('0x', iv.f_validator_pubkey) = vls.f_public_key
+" || { echo "$LOG_PREFIX ERROR: import into staging failed, live mapping untouched"; exit 1; }
+
+NEW_COUNT=$(ch "SELECT count() FROM t_eth2_pubkeys_staging") || exit 1
+echo "$LOG_PREFIX New snapshot: $NEW_COUNT entries"
+
+# ---------------------------------------------------------------- sanity gates
+if [ "$NEW_COUNT" -eq 0 ]; then
+    echo "$LOG_PREFIX GATE FAILED: new snapshot is empty, live mapping untouched"
+    exit 1
+fi
+
+if [ "$PREV_COUNT" -gt 0 ]; then
+    ok=$(awk -v new="$NEW_COUNT" -v prev="$PREV_COUNT" -v ratio="$SYNC_MIN_COUNT_RATIO" \
+        'BEGIN { print (new >= prev * ratio) ? 1 : 0 }')
+    if [ "$ok" -ne 1 ]; then
+        echo "$LOG_PREFIX GATE FAILED: snapshot shrank from $PREV_COUNT to $NEW_COUNT entries (min ratio $SYNC_MIN_COUNT_RATIO), live mapping untouched"
+        exit 1
+    fi
+fi
+
+if [ "$PREV_COUNT" -gt 0 ] && [ "$SYNC_MAX_POOL_DROP" -gt 0 ]; then
+    ch "SELECT f_pool_name, count() FROM t_eth2_pubkeys_staging FINAL GROUP BY f_pool_name FORMAT TSV" \
+        > "$TMPDIR_SYNC/pools_new.tsv" || exit 1
+    ALLOWLIST="${SYNC_POOL_RENAME_ALLOWLIST}"
+    VIOLATIONS=$(awk -F'\t' -v maxdrop="$SYNC_MAX_POOL_DROP" -v allowfile="$ALLOWLIST" '
+        BEGIN {
+            if (allowfile != "") {
+                while ((getline line < allowfile) > 0) { allowed[line] = 1 }
+                close(allowfile)
+            }
+        }
+        NR == FNR { newc[$1] = $2; next }
+        {
+            drop = $2 - newc[$1]
+            if (drop > maxdrop && !($1 in allowed)) {
+                printf "%s lost %d validators (%d -> %d)\n", $1, drop, $2, newc[$1]
+            }
+        }
+    ' "$TMPDIR_SYNC/pools_new.tsv" "$TMPDIR_SYNC/pools_prev.tsv")
+    if [ -n "$VIOLATIONS" ]; then
+        echo "$LOG_PREFIX GATE FAILED: pool drops above threshold ($SYNC_MAX_POOL_DROP), live mapping untouched."
+        echo "$LOG_PREFIX If these are legitimate renames or splits, add the pool names to the rename allowlist and rerun:"
+        echo "$VIOLATIONS" | while read -r line; do echo "$LOG_PREFIX   $line"; done
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------- atomic apply
+echo "$LOG_PREFIX Gates passed. Applying snapshot atomically..."
+ch "EXCHANGE TABLES t_eth2_pubkeys AND t_eth2_pubkeys_staging" || exit 1
+
+VERSION=$(date +%s)
+ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_version (
+        f_version UInt64,
+        f_synced_at DateTime,
+        f_entries UInt64
+    ) ENGINE = ReplacingMergeTree(f_version) ORDER BY tuple()" || exit 1
+ch "INSERT INTO t_eth2_pubkeys_version VALUES ($VERSION, now(), $NEW_COUNT)" || exit 1
+
+echo "$LOG_PREFIX Applied version $VERSION: $PREV_COUNT -> $NEW_COUNT entries"
+echo "$LOG_PREFIX Previous mapping kept in t_eth2_pubkeys_staging (rollback: EXCHANGE TABLES again)"
+status=0

--- a/scripts/sync-labels-to-clickhouse.sh
+++ b/scripts/sync-labels-to-clickhouse.sh
@@ -157,6 +157,31 @@ fi
 echo "$LOG_PREFIX Gates passed. Applying snapshot atomically..."
 ch "EXCHANGE TABLES t_eth2_pubkeys AND t_eth2_pubkeys_staging" || exit 1
 
+# ------------------------------------------------- optional t_pubkey_pool mirror
+# Some deployments also serve a pubkey -> pool mirror without requiring a
+# val_idx assignment (labels for deposits still in the pending queue). Same
+# staging + EXCHANGE pattern; the source snapshot already passed the gates.
+if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
+    echo "$LOG_PREFIX Syncing t_pubkey_pool mirror..."
+    ch "CREATE TABLE IF NOT EXISTS t_pubkey_pool_staging AS t_pubkey_pool" || exit 1
+    ch "TRUNCATE TABLE t_pubkey_pool_staging" || exit 1
+    ch "
+        INSERT INTO t_pubkey_pool_staging (f_public_key, f_pool_name)
+        SELECT
+            concat('0x', iv.f_validator_pubkey) AS f_public_key,
+            iv.f_pool_name
+        FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
+    " || { echo "$LOG_PREFIX ERROR: t_pubkey_pool import failed, live mirror untouched"; exit 1; }
+    PP_COUNT=$(ch "SELECT count() FROM t_pubkey_pool_staging") || exit 1
+    if [ "$PP_COUNT" -eq 0 ]; then
+        echo "$LOG_PREFIX GATE FAILED: t_pubkey_pool snapshot is empty, live mirror untouched"
+        exit 1
+    fi
+    ch "EXCHANGE TABLES t_pubkey_pool AND t_pubkey_pool_staging" || exit 1
+    echo "$LOG_PREFIX t_pubkey_pool updated: $PP_COUNT entries"
+fi
+
+# ------------------------------------------------- version stamp
 VERSION=$(date +%s)
 ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_version (
         f_version UInt64,

--- a/scripts/sync-labels-to-clickhouse.sh
+++ b/scripts/sync-labels-to-clickhouse.sh
@@ -113,11 +113,28 @@ if [ "$PREV_COUNT" -gt 0 ] && [ "$SYNC_MAX_POOL_DROP" -gt 0 ]; then
         > "$TMPDIR_SYNC/pools_prev.tsv" || exit 1
 fi
 
-# ---------------------------------------------------------------- import to staging
+# ---------------------------------------------------------------- import snapshot
+# Postgres is read exactly ONCE per run into t_labels_snapshot; the main
+# mapping and the optional t_pubkey_pool mirror are both derived from it, so
+# every distributed table reflects the same instant of the source and the
+# gates below vouch for all of them. A second postgresql() read for the
+# mirror would reintroduce the cross-table drift issue #31 exists to prevent.
+ch "CREATE TABLE IF NOT EXISTS t_labels_snapshot (
+        f_validator_pubkey String,
+        f_pool_name String
+    ) ENGINE = MergeTree ORDER BY tuple()" || exit 1
+ch "TRUNCATE TABLE t_labels_snapshot" || exit 1
+
+echo "$LOG_PREFIX Importing labels snapshot from Postgres..."
+ch "
+    INSERT INTO t_labels_snapshot (f_validator_pubkey, f_pool_name)
+    SELECT f_validator_pubkey, f_pool_name
+    FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}')
+" || { echo "$LOG_PREFIX ERROR: snapshot import failed, live mapping untouched"; exit 1; }
+
 ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_staging AS t_eth2_pubkeys" || exit 1
 ch "TRUNCATE TABLE t_eth2_pubkeys_staging" || exit 1
 
-echo "$LOG_PREFIX Importing snapshot into t_eth2_pubkeys_staging..."
 ch "
     INSERT INTO t_eth2_pubkeys_staging (f_val_idx, f_public_key, f_pool_name, f_pool)
     SELECT
@@ -125,7 +142,7 @@ ch "
         vls.f_public_key,
         iv.f_pool_name,
         iv.f_pool_name AS f_pool
-    FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
+    FROM t_labels_snapshot AS iv
     INNER JOIN t_validator_last_status AS vls
         ON concat('0x', iv.f_validator_pubkey) = vls.f_public_key
 " || { echo "$LOG_PREFIX ERROR: import into staging failed, live mapping untouched"; exit 1; }
@@ -190,7 +207,8 @@ post_swap_fail() {
 # ------------------------------------------------- optional t_pubkey_pool mirror
 # Some deployments also serve a pubkey -> pool mirror without requiring a
 # val_idx assignment (labels for deposits still in the pending queue). Same
-# staging + EXCHANGE pattern; the source snapshot already passed the gates.
+# staging + EXCHANGE pattern, built from t_labels_snapshot: the exact same
+# gated read of Postgres the main mapping was built from, never a second one.
 if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
     echo "$LOG_PREFIX Syncing t_pubkey_pool mirror..."
     ch "CREATE TABLE IF NOT EXISTS t_pubkey_pool_staging AS t_pubkey_pool" || post_swap_fail "t_pubkey_pool staging setup"
@@ -200,8 +218,8 @@ if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
         SELECT
             concat('0x', iv.f_validator_pubkey) AS f_public_key,
             iv.f_pool_name
-        FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
-    " || post_swap_fail "t_pubkey_pool import (live mirror untouched)"
+        FROM t_labels_snapshot AS iv
+    " || post_swap_fail "t_pubkey_pool build (live mirror untouched)"
     PP_COUNT=$(ch "SELECT count() FROM t_pubkey_pool_staging") || post_swap_fail "t_pubkey_pool count"
     if [ "$PP_COUNT" -eq 0 ]; then
         post_swap_fail "t_pubkey_pool gate: snapshot is empty (live mirror untouched)"
@@ -209,6 +227,8 @@ if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
     ch "EXCHANGE TABLES t_pubkey_pool AND t_pubkey_pool_staging" || post_swap_fail "t_pubkey_pool swap (live mirror untouched)"
     echo "$LOG_PREFIX t_pubkey_pool updated: $PP_COUNT entries"
 fi
+
+ch "TRUNCATE TABLE t_labels_snapshot" || true
 
 # ------------------------------------------------- version stamp
 VERSION=$(date +%s)

--- a/scripts/sync-labels-to-clickhouse.sh
+++ b/scripts/sync-labels-to-clickhouse.sh
@@ -36,6 +36,17 @@
 #                              exempt from the pool-drop gate (renames/splits)
 #   TEXTFILE_DIR               optional node_exporter textfile directory
 #   CRON_NAME                  metric label (default: labels_sync)
+#   SYNC_LOCK_FILE             lock path (default: /tmp/labels-sync-<db>-<port>.lock)
+#
+# Credentials: the ClickHouse password travels via the CLICKHOUSE_PASSWORD
+# environment variable and queries via stdin, never on a command line (which
+# any local user can read in /proc/<pid>/cmdline). Docker-based CH_CLIENT
+# values must forward the variable, e.g.:
+#   CH_CLIENT="docker exec -i -e CLICKHOUSE_PASSWORD my-clickhouse clickhouse-client"
+# The Postgres credentials are embedded in the postgresql() query text by
+# necessity (table function syntax); stdin keeps them off the process list
+# and ClickHouse masks table function secrets in its query_log. A server-side
+# named collection removes them from the query text entirely if preferred.
 #
 set -u
 
@@ -76,8 +87,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# One run at a time per target database: overlapping runs would race on the
+# same staging table and a double EXCHANGE could silently re-apply a stale
+# mapping with both runs reporting success.
+SYNC_LOCK_FILE="${SYNC_LOCK_FILE:-/tmp/labels-sync-${CH_DB}-${CH_PORT}.lock}"
+exec 9>"$SYNC_LOCK_FILE"
+if ! flock -n 9; then
+    echo "$LOG_PREFIX ERROR: another sync targeting ${CH_DB}:${CH_PORT} is still running (lock: $SYNC_LOCK_FILE), aborting"
+    exit 1
+fi
+
+export CLICKHOUSE_PASSWORD="$CH_PASS"
 ch() {
-    $CH_CLIENT --port "$CH_PORT" --user "$CH_USER" --password "$CH_PASS" --database "$CH_DB" --query "$1"
+    printf '%s' "$1" | $CH_CLIENT --port "$CH_PORT" --user "$CH_USER" --database "$CH_DB"
 }
 
 echo "$LOG_PREFIX $(date -u +%FT%TZ) Starting labels sync..."
@@ -157,27 +179,34 @@ fi
 echo "$LOG_PREFIX Gates passed. Applying snapshot atomically..."
 ch "EXCHANGE TABLES t_eth2_pubkeys AND t_eth2_pubkeys_staging" || exit 1
 
+# From this point on the new mapping is LIVE: any failure below makes the run
+# exit non-zero for alerting purposes, but must not be read as "the sync did
+# not happen". Rolling back requires an explicit EXCHANGE TABLES, not a rerun.
+post_swap_fail() {
+    echo "$LOG_PREFIX WARNING: $1 failed AFTER the swap: the new t_eth2_pubkeys mapping IS already live. Do not roll back based on this exit code alone."
+    exit 1
+}
+
 # ------------------------------------------------- optional t_pubkey_pool mirror
 # Some deployments also serve a pubkey -> pool mirror without requiring a
 # val_idx assignment (labels for deposits still in the pending queue). Same
 # staging + EXCHANGE pattern; the source snapshot already passed the gates.
 if [ "${SYNC_PUBKEY_POOL:-false}" = "true" ]; then
     echo "$LOG_PREFIX Syncing t_pubkey_pool mirror..."
-    ch "CREATE TABLE IF NOT EXISTS t_pubkey_pool_staging AS t_pubkey_pool" || exit 1
-    ch "TRUNCATE TABLE t_pubkey_pool_staging" || exit 1
+    ch "CREATE TABLE IF NOT EXISTS t_pubkey_pool_staging AS t_pubkey_pool" || post_swap_fail "t_pubkey_pool staging setup"
+    ch "TRUNCATE TABLE t_pubkey_pool_staging" || post_swap_fail "t_pubkey_pool staging truncate"
     ch "
         INSERT INTO t_pubkey_pool_staging (f_public_key, f_pool_name)
         SELECT
             concat('0x', iv.f_validator_pubkey) AS f_public_key,
             iv.f_pool_name
         FROM postgresql('${PG_HOST}:${PG_PORT}', '${PG_DB}', 't_identified_validators', '${PG_USER}', '${PG_PASS}') AS iv
-    " || { echo "$LOG_PREFIX ERROR: t_pubkey_pool import failed, live mirror untouched"; exit 1; }
-    PP_COUNT=$(ch "SELECT count() FROM t_pubkey_pool_staging") || exit 1
+    " || post_swap_fail "t_pubkey_pool import (live mirror untouched)"
+    PP_COUNT=$(ch "SELECT count() FROM t_pubkey_pool_staging") || post_swap_fail "t_pubkey_pool count"
     if [ "$PP_COUNT" -eq 0 ]; then
-        echo "$LOG_PREFIX GATE FAILED: t_pubkey_pool snapshot is empty, live mirror untouched"
-        exit 1
+        post_swap_fail "t_pubkey_pool gate: snapshot is empty (live mirror untouched)"
     fi
-    ch "EXCHANGE TABLES t_pubkey_pool AND t_pubkey_pool_staging" || exit 1
+    ch "EXCHANGE TABLES t_pubkey_pool AND t_pubkey_pool_staging" || post_swap_fail "t_pubkey_pool swap (live mirror untouched)"
     echo "$LOG_PREFIX t_pubkey_pool updated: $PP_COUNT entries"
 fi
 
@@ -187,8 +216,8 @@ ch "CREATE TABLE IF NOT EXISTS t_eth2_pubkeys_version (
         f_version UInt64,
         f_synced_at DateTime,
         f_entries UInt64
-    ) ENGINE = ReplacingMergeTree(f_version) ORDER BY tuple()" || exit 1
-ch "INSERT INTO t_eth2_pubkeys_version VALUES ($VERSION, now(), $NEW_COUNT)" || exit 1
+    ) ENGINE = ReplacingMergeTree(f_version) ORDER BY tuple()" || post_swap_fail "version table setup"
+ch "INSERT INTO t_eth2_pubkeys_version VALUES ($VERSION, now(), $NEW_COUNT)" || post_swap_fail "version stamp"
 
 echo "$LOG_PREFIX Applied version $VERSION: $PREV_COUNT -> $NEW_COUNT entries"
 echo "$LOG_PREFIX Previous mapping kept in t_eth2_pubkeys_staging (rollback: EXCHANGE TABLES again)"


### PR DESCRIPTION
Rolls up ten PRs merged to dev during the last two weeks. Everything here has been running in production since 2026-07-25, including one full weekly rebuild cycle. Grouped by theme for review.

## 1. Correctness fixes

**#30: owner tags win over operator tags.** The depositors phase and the withdrawal phase both upsert with last-write-wins semantics, so their relative order defines precedence. They ran in the wrong order: a batch-deposit operator (shared infrastructure) could override the withdrawal credential owner. Swapping the order (depositors first, withdrawal after) reattributed ~7.6k validators to their actual owners. See issue #28 for the full analysis.

**#38: deposits collector race.** The goroutine that persists downloaded deposit batches was never awaited, so the process could tear down the connection pool while the collector was still writing, dying with `could not acquire connection: closed pool`. The collector now has its own WaitGroup and the routine waits for it before returning. The race was as old as the collector and surfaced during benchmarking.

## 2. Identify performance: 24m53s to 5m52s measured in production

Daily production timings, before (2026-07-25) and after (2026-07-27):

| Phase | Before | After |
|---|---|---|
| AddNewValidators | 2m24s | 1m15s |
| IdentifyWhales | 1m59s | 2m30s (untouched) |
| ApplyDepositorsInsert | 5m42s | 32s |
| ApplyWithdrawalAddressInsert | 4m34s | 25s |
| IdentifyCoinbaseValidators | 32s | 8s |
| Lido (three modules) | 8m29s | 8s |
| ApplyValidatorsInsert | 1m11s | 50s |
| Total | 24m53s | 5m52s |

**#35: incremental daily runs.** `RECREATE_TABLE` becomes an explicit env toggle instead of an unconditional nightly truncate: weekdays run incrementally, Sundays do the full rebuild (crontab driven). Write-avoidance guards (`IS DISTINCT FROM`) added across phases, plus lookup indexes on t_beacon_deposits (migration 000010).

**#36: materialized latest deposit per validator.** New table t_validator_last_deposit (migration 000011) holds each validator's latest depositor and latest non-empty withdrawal address. It is refreshed inside the same transaction that inserts new deposit batches, with DISTINCT ON deduplication and monotonic block guards so the re-scan of recent blocks stays idempotent. The three queries that previously recomputed this with window scans over the whole deposits table (2.5M rows) are now plain joins. Note for deployment: the migration backfill took ~20 minutes on production-size data because the indexes exist during the insert; it runs once.

**#37: incremental Lido key fetching.** The stored key count per (protocol, operator index) acts as a checkpoint against the on-chain totals that operator data already includes for free. Unchanged operators are skipped entirely (typically 730 of 730), grown operators fetch only the new key range through a new append-only upsert (the existing reconcile deletes anything absent from the set it receives, so partial sets must never reach it), and shrunk operators trigger the full fetch plus reconcile. Operator data calls moved inside the existing worker pool, and a failing operator no longer aborts the module (the CSM path previously killed the whole process via log.Fatalf). Each module logs a `skipped/incremental/full` summary.

**#39: prune upsert probes.** INSERT ON CONFLICT probes the target index once per candidate row even when the guard then discards the write; two phases were feeding it millions of candidates to apply a few dozen changes. Anti-joins now compute the actual delta before the insert. The global Lido pool-name UPDATE also ran once per module (three times per run) and now runs once at the end.

**#40: respect phase precedence.** Measured with EXPLAIN ANALYZE: every run, the depositors phase rewrote 292,723 rows whose tag belongs to a later phase (284,565 of them Lido operators), the withdrawal phase then rewrote ~129k rows broken by that stomp, and the later phases reverted everything back. The two phases now skip candidates claimed by later phases (pubkeys in t_lido, t_rocketpool or t_validators_insert, mapped withdrawal addresses, rows tagged coinbase), and the final validators insert gains the standard write guard it lacked. Around 500k self-cancelling writes per run eliminated; this was also the main source of table bloat (a VACUUM FULL reclaimed 54% of the table afterwards). Claims are read at phase start, so a validator leaving a claiming set keeps its old tag for one extra run; the weekly rebuild replays original semantics and erases any such drift.

**#33: skip transfer fetching for strongly tagged depositors.** The transactions phase re-fetched transfer history for every known depositor. Depositors whose validators already carry a strong tag (anything except empty, solo_stakers or whale prefixes) are skipped: 119k of 301k depositors at the time of writing, ~60% of that job.

## 3. Labels sync tooling (new scripts/ directory)

**#32: atomic, versioned and gated sync to ClickHouse.** Generic script replacing ad hoc per-consumer copies of a truncate-and-reload flow that left readers with empty or partial label tables during every sync. It loads into a staging table and swaps with EXCHANGE TABLES (atomic, no reader downtime), stamps each applied snapshot in a version table, exports node_exporter metrics, and refuses to apply snapshots that fail sanity gates: minimum row-count ratio, per-pool drop threshold, and a rename allowlist. The gates proved themselves during the first weekly rebuild: a consumer's scheduled sync photographed the labels database mid-rebuild (all operator tags temporarily reset) and the gate rejected the snapshot instead of propagating it, keeping the last good state until the next cycle.

**#34: optional pubkey-to-pool mirror.** With SYNC_PUBKEY_POOL=true the script also maintains a full pubkey/pool mirror table for consumers that need per-validator granularity, built and swapped with the same staging pattern.

**Generic launcher (committed to dev directly, 728c1bd).** scripts/run-labels-sync.sh is the cron entry point: it sources a local env file (credentials and endpoints, the only piece that stays outside the repo), optionally opens an SSH tunnel to the labels Postgres with an active wait until the port answers, runs the sync engine and closes the tunnel on exit. Consumers previously carried hand-written copies of this plumbing; now every deployment runs the same reviewed logic.

Documentation for all of it in scripts/README.md.

## 4. Operational model after this release

- Weekdays 02:00: incremental identify (~6 min), labels change volume in the hundreds of rows.
- Sundays 02:00: full rebuild (~3h), truncate and replay with no shortcuts, absorbing any drift the incremental heuristics cannot see (operator renames, removed keys, mapping edits on strongly tagged validators).
- Consumers sync every 6h through the gated script and refresh their rollups automatically when the mapping fingerprint changes.
- Known minor gap: a consumer sync scheduled inside the Sunday rebuild window loses that one cycle (the gate blocks the partial snapshot by design and the next cycle catches up). Fix under discussion: shift the schedule or publish a completion marker the sync can check.

## Rollback

Each PR is independently revertable. Migration 000011 has a down (drops the table); the pre-#36 queries carry no extra state. The Sunday rebuild reconstructs t_identified_validators and t_validator_last_deposit from scratch under any combination of reverts.
