### PR TITLE
feat(identify): dual tagging, pure custodian and operator dimension columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ This table stores the validators with the pool/entity that operates them. Uniden
 
 - `f_validator_pubkey`: The public key of the validator.
 - `f_pool_name`: The name of the pool in which the validators are participating.
+- `f_operator` / `f_custodian`: see [Dual tagging](#dual-tagging-custodian--operator).
+
+## Dual tagging (custodian / operator)
+
+Custody (who controls the withdrawal credentials) and operation (who runs the validator) are two different questions, and `f_pool_name` can only store one answer: when both are known and differ, the [identification priority](#identification-priority) decides which one survives. The dimension columns give each answer its own slot:
+
+- `f_operator`: pure operation label. Sources, strongest first: Lido registry operator name, Rocket Pool registry, depositor mapping (`t_depositors_insert`), coinbase detection as fallback.
+- `f_custodian`: pure custody label. Sources: withdrawal address mapping (`t_withdrawal_address_insert`), coinbase detection as fallback.
+
+Semantics to keep in mind:
+
+- `NULL` means "no declared signal for this dimension", not "unknown entity".
+- Heuristic labels (`whale_0x...`, `solo_stakers`) and manual pins (`t_validators_insert`) live only in `f_pool_name`: their dimension is undeclared, so they never populate the pure columns.
+- `f_pool_name` keeps its historical behavior and priority chain unchanged: it is the display/legacy label and existing consumers are unaffected.
+- The columns are recomputed at the end of every identify run, deterministically from the mapping tables, so incremental runs and full rebuilds converge to the same values.
+
+Because each dimension has its own column, populating a custody mapping can never be shadowed by an operator label (or the other way around): the mapping tables can grow freely in both dimensions.
 
 ## Utilizing custom off-chain data
 

--- a/db/dimension_columns.go
+++ b/db/dimension_columns.go
@@ -1,0 +1,100 @@
+package db
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// One declarative pass computes both pure dimensions from their sources,
+	// with no precedence BETWEEN dimensions (that arbitration is exactly what
+	// the legacy f_pool_name does and what these columns exist to avoid).
+	// Within each dimension, stronger evidence wins:
+	//
+	//   f_operator:  Lido registry > Rocket Pool registry > depositor mapping
+	//                > coinbase detection (fallback: detected validators are
+	//                operated by the exchange unless a better signal exists;
+	//                the depositor mapping beats it because e.g. blockdaemon
+	//                operates validators whose custody is coinbase's).
+	//   f_custodian: withdrawal address mapping > coinbase detection (same
+	//                fallback reasoning on the custody side).
+	//
+	// Heuristic labels (whales, solo_stakers) and manual pins only exist in
+	// f_pool_name: their dimension is undeclared, so they never feed the pure
+	// columns. NULL here means "no declared signal", not "unknown entity".
+	//
+	// The change guard keeps steady-state runs down to the real daily delta;
+	// the first run after the migration rewrites every row once (write volume
+	// comparable to a weekly full rebuild, which production absorbs weekly).
+	applyDimensionColumnsQuery = `
+		UPDATE t_identified_validators t
+		SET f_operator = src.op,
+		    f_custodian = src.cust
+		FROM (
+			SELECT
+				v.f_validator_pubkey,
+				COALESCE(
+					l.f_operator,
+					CASE WHEN r.f_validator_pubkey IS NOT NULL THEN 'rocketpool' END,
+					md.f_pool_name,
+					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
+				) AS op,
+				COALESCE(
+					mw.f_pool_name,
+					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
+				) AS cust
+			FROM t_validator_last_deposit v
+			JOIN t_identified_validators cur
+				ON cur.f_validator_pubkey = v.f_validator_pubkey
+			LEFT JOIN t_lido l
+				ON l.f_validator_pubkey = v.f_validator_pubkey
+			LEFT JOIN t_rocketpool r
+				ON r.f_validator_pubkey = v.f_validator_pubkey
+			LEFT JOIN t_depositors_insert md
+				ON md.f_depositor = v.f_depositor
+			LEFT JOIN t_withdrawal_address_insert mw
+				ON mw.f_withdrawal_address = v.f_withdrawal_address
+				AND v.f_withdrawal_address != ''
+		) src
+		WHERE t.f_validator_pubkey = src.f_validator_pubkey
+		  AND (t.f_operator IS DISTINCT FROM src.op
+		       OR t.f_custodian IS DISTINCT FROM src.cust);
+	`
+
+	analyzeAfterDimensionRows = 100000
+)
+
+// ApplyDimensionColumns recomputes f_operator and f_custodian for every
+// validator whose derived values changed. Runs at the end of the identify
+// pipeline, after all phases and mappings have settled, and is deterministic
+// from the mapping tables: full rebuilds and incremental runs converge to the
+// same values. Returns the number of rows written.
+func (p *PostgresDBService) ApplyDimensionColumns() (int64, error) {
+	p.writerThreadsWG.Add(1)
+	defer p.writerThreadsWG.Done()
+	startTime := time.Now()
+
+	conn, err := p.psqlPool.Acquire(p.ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "error acquiring connection")
+	}
+	defer conn.Release()
+
+	cmd, err := conn.Exec(p.ctx, applyDimensionColumnsQuery)
+	if err != nil {
+		return 0, errors.Wrap(err, "error applying dimension columns")
+	}
+	rows := cmd.RowsAffected()
+
+	// A large write (first fill, weekly rebuild) skews planner stats; refresh
+	// them so the hourly queries keep good plans.
+	if rows > analyzeAfterDimensionRows {
+		if _, err := conn.Exec(p.ctx, `ANALYZE t_identified_validators;`); err != nil {
+			return rows, errors.Wrap(err, "error analyzing after dimension update")
+		}
+	}
+
+	wlog.Debugf("dimension columns updated: %d rows in %.2fs", rows, time.Since(startTime).Seconds())
+	return rows, nil
+}

--- a/db/migrations/000012_add_dimension_columns.down.sql
+++ b/db/migrations/000012_add_dimension_columns.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE t_identified_validators
+    DROP COLUMN IF EXISTS f_operator,
+    DROP COLUMN IF EXISTS f_custodian;

--- a/db/migrations/000012_add_dimension_columns.up.sql
+++ b/db/migrations/000012_add_dimension_columns.up.sql
@@ -1,0 +1,26 @@
+-- Dual tagging (custodian / operator), phase 1 of issue #28's structural fix.
+--
+-- Custody (who controls the withdrawal credentials) and operation (who runs
+-- the validator) are two orthogonal dimensions that f_pool_name squeezes into
+-- a single value, so one signal always shadows the other and phase order acts
+-- as the arbiter. These columns give each dimension its own slot:
+--
+--   f_operator   pure operation label. Sources, strongest first: Lido registry
+--                operator name, Rocket Pool registry, depositor mapping
+--                (t_depositors_insert), coinbase detection as fallback.
+--   f_custodian  pure custody label. Sources: withdrawal address mapping
+--                (t_withdrawal_address_insert), coinbase detection as fallback.
+--
+-- NULL means "no declared signal for this dimension", not "unknown entity".
+-- f_pool_name stays untouched as the legacy/display label with the historical
+-- precedence, including heuristics (whales, solo_stakers) and manual pins,
+-- which intentionally do NOT feed the pure columns: their dimension is
+-- undeclared. Existing consumers keep working unchanged.
+ALTER TABLE t_identified_validators
+    ADD COLUMN IF NOT EXISTS f_operator TEXT,
+    ADD COLUMN IF NOT EXISTS f_custodian TEXT;
+
+COMMENT ON COLUMN t_identified_validators.f_operator IS
+    'Pure operation dimension (who runs the validator). NULL = no declared operator signal. See migration 000012.';
+COMMENT ON COLUMN t_identified_validators.f_custodian IS
+    'Pure custody dimension (who controls the withdrawal credentials). NULL = no declared custodian signal. See migration 000012.';

--- a/identify/identify.go
+++ b/identify/identify.go
@@ -198,6 +198,20 @@ func (i *Identify) Run() {
 		}
 	}
 
+	// Pure dimension columns (custodian/operator) derive from the settled
+	// mappings, so they are computed once at the very end instead of taking
+	// part in the phase precedence dance. See migration 000012.
+	if !i.stop {
+		startTime := time.Now()
+		log.Info("Applying dimension columns (operator/custodian)")
+		rows, err := i.dbClient.ApplyDimensionColumns()
+		if err != nil {
+			log.Errorf("Error applying dimension columns: %v. Skipping to next step.", err)
+		} else {
+			log.Infof("Applied dimension columns (%d rows) in %v", rows, time.Since(startTime))
+		}
+	}
+
 	endTime := time.Now()
 	log.Infof("Identify routine finished in %v", endTime.Sub(initTime))
 	i.CloseConnections()


### PR DESCRIPTION
## Problem

Custody (who controls the withdrawal credentials) and operation (who runs the validator) are two orthogonal dimensions squeezed into the single `f_pool_name`, so when both are known and differ, the identification priority decides which one survives and the other is silently lost. Measured on production data before this change: 8,154 operator labels known and suppressed by the custodian-wins rule, 114k validators with both signals, and the custodian mapping table effectively frozen (mapping, say, Lido's withdrawal vault would be immediately shadowed by the operator names for 486k validators).

## Change

Phase 1 of the two-dimension model discussed in issue #28, additive and backward compatible:

- Migration 000012 adds two nullable columns to `t_identified_validators`: `f_operator` (pure operation label) and `f_custodian` (pure custody label). `NULL` means "no declared signal for this dimension", not "unknown entity".
- A single declarative pass at the end of every identify run computes both columns from the settled mappings, with no precedence BETWEEN dimensions. Within each dimension, stronger evidence wins: operator = Lido registry > Rocket Pool registry > depositor mapping > coinbase detection; custodian = withdrawal mapping > coinbase detection.
- Heuristic labels (whales, solo_stakers) and manual pins stay in `f_pool_name` only: their dimension is undeclared.
- `f_pool_name` keeps its historical behavior and priority chain untouched: no existing consumer (labels sync, ClickHouse, dashboards) sees any change.
- The pass carries the same write-avoidance guard as the other phases and refreshes planner stats automatically after large writes.

## Validation (run end to end on the production labels database)

- `f_pool_name` byte-identical before and after (only the day's new validators appeared).
- Population: 2,060,785 validators with an operator label, 385,001 with a custodian label, 379,040 with both.
- Every previously suppressed operator label surfaced exactly as measured: bloxstaking/abyss_finance 1,803, BitMine/piertwo 1,596, ether_capital/figment 1,124, ether_capital/kiln 900, coinbase/blockdaemon 261, and the rest.
- Lido: all 486,364 registry validators carry their pure operator name; custodian stays NULL until a vault mapping exists, and populating it can no longer be shadowed.
- Steady state proven with a second immediate run: the pass wrote 4 rows in 10.7 seconds.

## Operational notes

- First run after deploying rewrites every row once to fill the columns (observed 35 minutes under heavy concurrent load; expect less in a quiet window). Subsequent incremental runs write only the real delta.
- The weekly full rebuild truncates the table, so the pass refills all rows every rebuild: expect the rebuild to take roughly half an hour longer than before.
- Known data observation, out of scope here: 26 rows in the mapping tables declare whale-style or solo_stakers pool names, which flow into the pure columns as any declared mapping value does (10,384 validators). Declaring a dimension per mapping row is the phase 2 follow-up, together with exporting the new columns to consumers.

## Rollback

Migration down drops the two columns; no other state is involved. `f_pool_name` and every consumer are unaffected under any combination of reverts.
