### PR TITLE
feat(identify): declared-dimension pins for pure operator and custodian labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,14 @@ This table stores the validators with the pool/entity that operates them. Uniden
 
 Custody (who controls the withdrawal credentials) and operation (who runs the validator) are two different questions, and `f_pool_name` can only store one answer: when both are known and differ, the [identification priority](#identification-priority) decides which one survives. The dimension columns give each answer its own slot:
 
-- `f_operator`: pure operation label. Sources, strongest first: Lido registry operator name, Rocket Pool registry, depositor mapping (`t_depositors_insert`), coinbase detection as fallback.
-- `f_custodian`: pure custody label. Sources: withdrawal address mapping (`t_withdrawal_address_insert`), coinbase detection as fallback.
+- `f_operator`: pure operation label. Sources, strongest first: declared pin (`t_validators_insert` with `f_dimension = 'operator'`), Lido registry operator name, Rocket Pool registry, depositor mapping (`t_depositors_insert`), coinbase detection as fallback.
+- `f_custodian`: pure custody label. Sources, strongest first: declared pin (`f_dimension = 'custodian'`), withdrawal address mapping (`t_withdrawal_address_insert`), coinbase detection as fallback.
 
 Semantics to keep in mind:
 
 - `NULL` means "no declared signal for this dimension", not "unknown entity".
-- Heuristic labels (`whale_0x...`, `solo_stakers`) and manual pins (`t_validators_insert`) live only in `f_pool_name`: their dimension is undeclared, so they never populate the pure columns.
+- Heuristic labels (`whale_0x...`, `solo_stakers`) and legacy pins (`t_validators_insert` rows with `f_dimension` `NULL`) live only in `f_pool_name`: their dimension is undeclared, so they never populate the pure columns.
+- Declared pins (`f_dimension` set to `operator` or `custodian`) are the opposite: they populate only their pure column and never touch `f_pool_name`. Use them for curated per-pubkey facts the address-level mappings cannot express, e.g. a third party operating validators deposited by a liquid-restaking platform.
 - `f_pool_name` keeps its historical behavior and priority chain unchanged: it is the display/legacy label and existing consumers are unaffected.
 - The columns are recomputed at the end of every identify run, deterministically from the mapping tables, so incremental runs and full rebuilds converge to the same values.
 
@@ -187,7 +188,14 @@ This table has the columns `f_depositor` and `f_pool_name`. The `identify` comma
 
 ### `t_validators_insert`
 
-This table has the columns `f_validator_pubkey` and `f_pool_name`. The `identify` command will use this table to identify the pool in which the validators are participating. The `f_validator_pubkey` column is the address of the validator and the `f_pool_name` is the name of the pool in which the validators are participating. These values will be used to tag the validators and will override any other tag that the validator might have been given.
+This table has the columns `f_validator_pubkey`, `f_pool_name` and `f_dimension`. The `identify` command will use this table to identify the pool in which the validators are participating. The `f_validator_pubkey` column is the address of the validator and the `f_pool_name` is the name of the pool in which the validators are participating.
+
+The `f_dimension` column selects what the row asserts:
+
+- `NULL` (default): legacy pin. The value is written to `f_pool_name` and overrides any other tag the validator might have been given.
+- `'operator'` or `'custodian'`: declared pin. The value is written only to the corresponding pure dimension column (see [Dual tagging](#dual-tagging-custodian--operator)) and `f_pool_name` is left untouched.
+
+One row per pubkey: a validator cannot carry a legacy pin and a declared pin at the same time.
 
 ### `t_withdrawal_address_insert`
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Semantics to keep in mind:
 
 - `NULL` means "no declared signal for this dimension", not "unknown entity".
 - Heuristic labels (`whale_0x...`, `solo_stakers`) and legacy pins (`t_validators_insert` rows with `f_dimension` `NULL`) live only in `f_pool_name`: their dimension is undeclared, so they never populate the pure columns.
-- Declared pins (`f_dimension` set to `operator` or `custodian`) are the opposite: they populate only their pure column and never touch `f_pool_name`. Use them for curated per-pubkey facts the address-level mappings cannot express, e.g. a third party operating validators deposited by a liquid-restaking platform.
+- Operator pins (`f_dimension = 'operator'`) populate `f_operator` and also claim the display label, because entities are the operator when known (the same reason Lido validators show their operator instead of `lido`). Use them for curated per-pubkey facts the address-level mappings cannot express, e.g. a third party operating validators deposited by a liquid-restaking platform.
+- Custodian pins (`f_dimension = 'custodian'`) populate only `f_custodian` and never touch `f_pool_name`.
 - `f_pool_name` keeps its historical behavior and priority chain unchanged: it is the display/legacy label and existing consumers are unaffected.
 - The columns are recomputed at the end of every identify run, deterministically from the mapping tables, so incremental runs and full rebuilds converge to the same values.
 
@@ -193,7 +194,8 @@ This table has the columns `f_validator_pubkey`, `f_pool_name` and `f_dimension`
 The `f_dimension` column selects what the row asserts:
 
 - `NULL` (default): legacy pin. The value is written to `f_pool_name` and overrides any other tag the validator might have been given.
-- `'operator'` or `'custodian'`: declared pin. The value is written only to the corresponding pure dimension column (see [Dual tagging](#dual-tagging-custodian--operator)) and `f_pool_name` is left untouched.
+- `'operator'`: the value is written to `f_operator` (see [Dual tagging](#dual-tagging-custodian--operator)) and to `f_pool_name`, overriding any other tag.
+- `'custodian'`: the value is written only to `f_custodian`; `f_pool_name` is left untouched.
 
 One row per pubkey: a validator cannot carry a legacy pin and a declared pin at the same time.
 

--- a/db/coinbase.go
+++ b/db/coinbase.go
@@ -3,57 +3,67 @@ package db
 import "github.com/pkg/errors"
 
 const (
+	// Persists the full detection result into t_coinbase_detected (migration
+	// 000014). The set is derived from on-chain facts only, so it can only
+	// grow; keeping it materialized lets the display update below and the
+	// dimension pass (ApplyDimensionColumns) recognize coinbase-detected
+	// validators even after a later phase or a display-claiming pin has
+	// overwritten their f_pool_name.
+	persistCoinbaseDetectedQuery = `
+	INSERT INTO t_coinbase_detected (f_validator_pubkey)
+	SELECT distinct f_validator_pubkey from t_beacon_depositors_transactions
+	JOIN t_beacon_deposits on t_beacon_deposits.f_tx_hash=t_beacon_depositors_transactions.f_tx_hash
+	WHERE
+	f_to = '00000000219ab540356cbb839cbe05303d7705fa'
+	AND f_from in (
+		select f_from from t_beacon_depositors_transactions
+		where
+		f_from in (
+			SELECT
+			f_from
+			FROM
+			t_beacon_depositors_transactions
+			where
+			f_to = '00000000219ab540356cbb839cbe05303d7705fa'
+			group by
+			f_from
+			having
+			count(*) = 1
+		)
+		AND f_to in(
+			'a090e606e30bd747d4e6245a1517ebe430f0057e',
+			'71660c4005ba85c37ccec55d0c4493e66fe775d3',
+			'a9d1e08c7793af67e9d92fe308d5697fb81d3e43',
+			'77696bb39917c91a0c3908d577d5e322095425ca',
+			'7c195d981abfdc3ddecd2ca0fed0958430488e34',
+			'95a9bd206ae52c4ba8eecfc93d18eacdd41c88cc',
+			'b739d0895772dbb71a89a3754a160269068f0d45',
+			'503828976d22510aad0201ac7ec88293211d23da',
+			'ddfabcdc4d8ffc6d5beaf154f18b778f892a0740',
+			'3cd751e6b0078be393132286c442345e5dc49699',
+			'b5d85cbf7cb3ee0d56b3bb207d5fc4b82f43f511',
+			'eb2629a2734e272bcc07bda959863f316f4bd4cf',
+			'd688aea8f7d450909ade10c47faa95707b0682d9',
+			'02466e547bfdab679fc49e96bbfc62b9747d997c',
+			'6b76f8b1e9e59913bfe758821887311ba1805cab',
+			'be3c68821d585cf1552214897a1c091014b1eb0a',
+			'f6874c88757721a02f47592140905c4336dfbc61',
+			'881d4032abe4188e2237efcd27ab435e81fc6bb1',
+			'6c8dd0e9cc58c07429e065178d88444b60e60b80',
+			'bc8ec259e3026ae0d87bc442d034d6882ce4a35c',
+			'02d24cab4f2c3bf6e6eb07ea07e45f96baccffe7',
+			'ce352e98934499be70f641353f16a47d9e1e3abd',
+			'90e18a6920985dbacc3d76cf27a3f2131923c720',
+			'4b23d52eff7c67f5992c2ab6d3f69b13a6a33561',
+			'd2276af80582cac230edc4c42e9a9c096f3c09aa')
+	)
+	ON CONFLICT (f_validator_pubkey) DO NOTHING
+	`
+
 	identifyCoinbaseValidatorsQuery = `
 	UPDATE t_identified_validators
 	SET f_pool_name = 'coinbase'
-	WHERE f_validator_pubkey in (
-		SELECT distinct f_validator_pubkey from t_beacon_depositors_transactions
-		JOIN t_beacon_deposits on t_beacon_deposits.f_tx_hash=t_beacon_depositors_transactions.f_tx_hash
-		WHERE 
-		f_to = '00000000219ab540356cbb839cbe05303d7705fa'
-		AND f_from in (
-			select f_from from t_beacon_depositors_transactions 
-			where 
-			f_from in (
-				SELECT 
-				f_from
-				FROM 
-				t_beacon_depositors_transactions 
-				where 
-				f_to = '00000000219ab540356cbb839cbe05303d7705fa' 
-				group by 
-				f_from 
-				having 
-				count(*) = 1
-			) 
-			AND f_to in(
-				'a090e606e30bd747d4e6245a1517ebe430f0057e',
-				'71660c4005ba85c37ccec55d0c4493e66fe775d3',
-				'a9d1e08c7793af67e9d92fe308d5697fb81d3e43',
-				'77696bb39917c91a0c3908d577d5e322095425ca',
-				'7c195d981abfdc3ddecd2ca0fed0958430488e34',
-				'95a9bd206ae52c4ba8eecfc93d18eacdd41c88cc',
-				'b739d0895772dbb71a89a3754a160269068f0d45',
-				'503828976d22510aad0201ac7ec88293211d23da',
-				'ddfabcdc4d8ffc6d5beaf154f18b778f892a0740',
-				'3cd751e6b0078be393132286c442345e5dc49699',
-				'b5d85cbf7cb3ee0d56b3bb207d5fc4b82f43f511',
-				'eb2629a2734e272bcc07bda959863f316f4bd4cf',
-				'd688aea8f7d450909ade10c47faa95707b0682d9',
-				'02466e547bfdab679fc49e96bbfc62b9747d997c',
-				'6b76f8b1e9e59913bfe758821887311ba1805cab',
-				'be3c68821d585cf1552214897a1c091014b1eb0a',
-				'f6874c88757721a02f47592140905c4336dfbc61',
-				'881d4032abe4188e2237efcd27ab435e81fc6bb1',
-				'6c8dd0e9cc58c07429e065178d88444b60e60b80',
-				'bc8ec259e3026ae0d87bc442d034d6882ce4a35c',
-				'02d24cab4f2c3bf6e6eb07ea07e45f96baccffe7',
-				'ce352e98934499be70f641353f16a47d9e1e3abd',
-				'90e18a6920985dbacc3d76cf27a3f2131923c720',
-				'4b23d52eff7c67f5992c2ab6d3f69b13a6a33561',
-				'd2276af80582cac230edc4c42e9a9c096f3c09aa')
-		)
-	)
+	WHERE f_validator_pubkey in (SELECT f_validator_pubkey FROM t_coinbase_detected)
 	AND f_pool_name IS DISTINCT FROM 'coinbase'
 	`
 )
@@ -67,7 +77,12 @@ func (p *PostgresDBService) IdentifyCoinbaseValidators() error {
 	}
 	defer conn.Release()
 
-	_, err = conn.Query(p.ctx, identifyCoinbaseValidatorsQuery)
+	_, err = conn.Exec(p.ctx, persistCoinbaseDetectedQuery)
+	if err != nil {
+		return errors.Wrap(err, "error persisting coinbase detection")
+	}
+
+	_, err = conn.Exec(p.ctx, identifyCoinbaseValidatorsQuery)
 	if err != nil {
 		return errors.Wrap(err, "error identifying coinbase validators")
 	}

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -29,11 +29,11 @@ const (
 				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
 			AND NOT EXISTS (SELECT 1 FROM t_lido l
 				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
-			-- Declared-dimension pins (migration 000013) never write
-			-- f_pool_name, so only legacy pins suppress this phase.
+			-- Custodian pins (migration 000013) never write f_pool_name, so
+			-- only pins that claim the display label suppress this phase.
 			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
 				WHERE vi.f_validator_pubkey = v.f_validator_pubkey
-				AND vi.f_dimension IS NULL)
+				AND vi.f_dimension IS DISTINCT FROM 'custodian')
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/depositors_insert.go
+++ b/db/depositors_insert.go
@@ -29,8 +29,11 @@ const (
 				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
 			AND NOT EXISTS (SELECT 1 FROM t_lido l
 				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			-- Declared-dimension pins (migration 000013) never write
+			-- f_pool_name, so only legacy pins suppress this phase.
 			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
-				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey
+				AND vi.f_dimension IS NULL)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/dimension_columns.go
+++ b/db/dimension_columns.go
@@ -12,17 +12,26 @@ const (
 	// the legacy f_pool_name does and what these columns exist to avoid).
 	// Within each dimension, stronger evidence wins:
 	//
-	//   f_operator:  Lido registry > Rocket Pool registry > depositor mapping
-	//                > coinbase detection (fallback: detected validators are
-	//                operated by the exchange unless a better signal exists;
-	//                the depositor mapping beats it because e.g. blockdaemon
-	//                operates validators whose custody is coinbase's).
-	//   f_custodian: withdrawal address mapping > coinbase detection (same
-	//                fallback reasoning on the custody side).
+	//   f_operator:  declared pin (f_dimension = 'operator') > Lido registry
+	//                > Rocket Pool registry > depositor mapping > coinbase
+	//                detection (fallback: detected validators are operated by
+	//                the exchange unless a better signal exists; the depositor
+	//                mapping beats it because e.g. blockdaemon operates
+	//                validators whose custody is coinbase's).
+	//   f_custodian: declared pin (f_dimension = 'custodian') > withdrawal
+	//                address mapping > coinbase detection (same fallback
+	//                reasoning on the custody side).
 	//
-	// Heuristic labels (whales, solo_stakers) and manual pins only exist in
-	// f_pool_name: their dimension is undeclared, so they never feed the pure
-	// columns. NULL here means "no declared signal", not "unknown entity".
+	// Declared pins (migration 000013) are curated per-pubkey facts, so they
+	// rank first in their dimension and double as the manual override; the
+	// depositor mapping in particular mislabels delegated operation (the
+	// depositor of e.g. a liquid-restaking validator is the platform, not
+	// whoever runs it), which is exactly what an operator pin corrects.
+	//
+	// Heuristic labels (whales, solo_stakers) and legacy pins (f_dimension
+	// IS NULL) only exist in f_pool_name: their dimension is undeclared, so
+	// they never feed the pure columns. NULL here means "no declared signal",
+	// not "unknown entity".
 	//
 	// The change guard keeps steady-state runs down to the real daily delta;
 	// the first run after the migration rewrites every row once (write volume
@@ -35,18 +44,26 @@ const (
 			SELECT
 				v.f_validator_pubkey,
 				COALESCE(
+					pinop.f_pool_name,
 					l.f_operator,
 					CASE WHEN r.f_validator_pubkey IS NOT NULL THEN 'rocketpool' END,
 					md.f_pool_name,
 					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
 				) AS op,
 				COALESCE(
+					pincust.f_pool_name,
 					mw.f_pool_name,
 					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
 				) AS cust
 			FROM t_validator_last_deposit v
 			JOIN t_identified_validators cur
 				ON cur.f_validator_pubkey = v.f_validator_pubkey
+			LEFT JOIN t_validators_insert pinop
+				ON pinop.f_validator_pubkey = v.f_validator_pubkey
+				AND pinop.f_dimension = 'operator'
+			LEFT JOIN t_validators_insert pincust
+				ON pincust.f_validator_pubkey = v.f_validator_pubkey
+				AND pincust.f_dimension = 'custodian'
 			LEFT JOIN t_lido l
 				ON l.f_validator_pubkey = v.f_validator_pubkey
 			LEFT JOIN t_rocketpool r

--- a/db/dimension_columns.go
+++ b/db/dimension_columns.go
@@ -42,32 +42,34 @@ const (
 		    f_custodian = src.cust
 		FROM (
 			SELECT
-				v.f_validator_pubkey,
+				cur.f_validator_pubkey,
 				COALESCE(
 					pinop.f_pool_name,
 					l.f_operator,
 					CASE WHEN r.f_validator_pubkey IS NOT NULL THEN 'rocketpool' END,
 					md.f_pool_name,
-					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
+					CASE WHEN cb.f_validator_pubkey IS NOT NULL THEN 'coinbase' END
 				) AS op,
 				COALESCE(
 					pincust.f_pool_name,
 					mw.f_pool_name,
-					CASE WHEN cur.f_pool_name = 'coinbase' THEN 'coinbase' END
+					CASE WHEN cb.f_validator_pubkey IS NOT NULL THEN 'coinbase' END
 				) AS cust
-			FROM t_validator_last_deposit v
-			JOIN t_identified_validators cur
-				ON cur.f_validator_pubkey = v.f_validator_pubkey
+			FROM t_identified_validators cur
+			LEFT JOIN t_validator_last_deposit v
+				ON v.f_validator_pubkey = cur.f_validator_pubkey
+			LEFT JOIN t_coinbase_detected cb
+				ON cb.f_validator_pubkey = cur.f_validator_pubkey
 			LEFT JOIN t_validators_insert pinop
-				ON pinop.f_validator_pubkey = v.f_validator_pubkey
+				ON pinop.f_validator_pubkey = cur.f_validator_pubkey
 				AND pinop.f_dimension = 'operator'
 			LEFT JOIN t_validators_insert pincust
-				ON pincust.f_validator_pubkey = v.f_validator_pubkey
+				ON pincust.f_validator_pubkey = cur.f_validator_pubkey
 				AND pincust.f_dimension = 'custodian'
 			LEFT JOIN t_lido l
-				ON l.f_validator_pubkey = v.f_validator_pubkey
+				ON l.f_validator_pubkey = cur.f_validator_pubkey
 			LEFT JOIN t_rocketpool r
-				ON r.f_validator_pubkey = v.f_validator_pubkey
+				ON r.f_validator_pubkey = cur.f_validator_pubkey
 			LEFT JOIN t_depositors_insert md
 				ON md.f_depositor = v.f_depositor
 			LEFT JOIN t_withdrawal_address_insert mw

--- a/db/migrations/000013_add_dimension_to_validators_insert.down.sql
+++ b/db/migrations/000013_add_dimension_to_validators_insert.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE t_validators_insert
+    DROP CONSTRAINT IF EXISTS t_validators_insert_dimension_check;
+
+ALTER TABLE t_validators_insert
+    DROP COLUMN IF EXISTS f_dimension;

--- a/db/migrations/000013_add_dimension_to_validators_insert.up.sql
+++ b/db/migrations/000013_add_dimension_to_validators_insert.up.sql
@@ -1,0 +1,30 @@
+-- Declared-dimension pins, phase 2 of issue #28's structural fix.
+--
+-- Phase 1 (migration 000012) computes the pure dimension columns from
+-- address-level mappings and on-chain registries. Those sources cannot express
+-- pubkey-level operator knowledge: the depositor of a delegated validator is
+-- its platform or custodian, not whoever runs the machines (e.g. validators
+-- deposited by a liquid-restaking protocol and operated by a third party).
+-- This column lets a t_validators_insert row declare WHICH dimension it
+-- asserts:
+--
+--   NULL          legacy pin: writes f_pool_name, never the pure columns.
+--   'operator'    writes f_operator only; f_pool_name is left untouched.
+--   'custodian'   writes f_custodian only; f_pool_name is left untouched.
+--
+-- Declared rows are the strongest evidence within their dimension: they are
+-- curated per-pubkey facts (DVT registries, operator-identifying graffiti,
+-- confirmed off-chain data), so they beat every inferred source and double as
+-- the manual override.
+--
+-- The primary key stays f_validator_pubkey: one row per pubkey, one assertion.
+-- A pubkey cannot carry a legacy pin and a declared pin at the same time.
+ALTER TABLE t_validators_insert
+    ADD COLUMN IF NOT EXISTS f_dimension TEXT;
+
+ALTER TABLE t_validators_insert
+    ADD CONSTRAINT t_validators_insert_dimension_check
+    CHECK (f_dimension IS NULL OR f_dimension IN ('operator', 'custodian'));
+
+COMMENT ON COLUMN t_validators_insert.f_dimension IS
+    'Dimension this pin asserts: NULL = legacy f_pool_name pin, operator = f_operator only, custodian = f_custodian only. See migration 000013.';

--- a/db/migrations/000013_add_dimension_to_validators_insert.up.sql
+++ b/db/migrations/000013_add_dimension_to_validators_insert.up.sql
@@ -9,7 +9,9 @@
 -- asserts:
 --
 --   NULL          legacy pin: writes f_pool_name, never the pure columns.
---   'operator'    writes f_operator only; f_pool_name is left untouched.
+--   'operator'    writes f_operator and also the display label: entities are
+--                 the operator when known (Lido validators show kiln, figment
+--                 and so on, not "lido"), so an operator pin claims both.
 --   'custodian'   writes f_custodian only; f_pool_name is left untouched.
 --
 -- Declared rows are the strongest evidence within their dimension: they are
@@ -27,4 +29,4 @@ ALTER TABLE t_validators_insert
     CHECK (f_dimension IS NULL OR f_dimension IN ('operator', 'custodian'));
 
 COMMENT ON COLUMN t_validators_insert.f_dimension IS
-    'Dimension this pin asserts: NULL = legacy f_pool_name pin, operator = f_operator only, custodian = f_custodian only. See migration 000013.';
+    'Dimension this pin asserts: NULL = legacy f_pool_name pin, operator = f_operator plus the display label, custodian = f_custodian only. See migration 000013.';

--- a/db/migrations/000014_add_coinbase_detected_table.down.sql
+++ b/db/migrations/000014_add_coinbase_detected_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.t_coinbase_detected;

--- a/db/migrations/000014_add_coinbase_detected_table.up.sql
+++ b/db/migrations/000014_add_coinbase_detected_table.up.sql
@@ -1,0 +1,20 @@
+-- Materializes the coinbase detection so the pure dimension columns do not
+-- depend on the mutable display label. Before this table, the dimension pass
+-- inferred "coinbase-detected" from f_pool_name = 'coinbase', which breaks as
+-- soon as a later phase or a display-claiming pin overwrites the label: the
+-- validator's coinbase custody and operation fallbacks silently disappear
+-- (review finding on PR #43). IdentifyCoinbaseValidators now persists its
+-- full detection result here (idempotent inserts, the set only grows) and
+-- both the display update and the dimension pass read from this table.
+CREATE TABLE IF NOT EXISTS public.t_coinbase_detected (
+    f_validator_pubkey TEXT NOT NULL,
+    CONSTRAINT t_coinbase_detected_pkey PRIMARY KEY (f_validator_pubkey)
+);
+
+-- Seed with the currently coinbase-labeled set: exactly the validators whose
+-- label came from the detection heuristic (or from a coinbase depositor
+-- mapping, whose custody is coinbase's in either case).
+INSERT INTO t_coinbase_detected (f_validator_pubkey)
+SELECT f_validator_pubkey FROM t_identified_validators
+WHERE f_pool_name = 'coinbase'
+ON CONFLICT (f_validator_pubkey) DO NOTHING;

--- a/db/validators_insert.go
+++ b/db/validators_insert.go
@@ -3,6 +3,9 @@ package db
 import "github.com/pkg/errors"
 
 const (
+	// Rows with a declared dimension assert f_operator or f_custodian only
+	// (see migration 000013 and ApplyDimensionColumns); they must not touch
+	// the legacy f_pool_name label.
 	applyValidatorsInsertQuery = `
 	INSERT INTO t_identified_validators (
 		f_validator_pubkey,
@@ -13,6 +16,7 @@ const (
 		f_pool_name
 	FROM
 		t_validators_insert
+	WHERE f_dimension IS NULL
 	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name
 	WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`

--- a/db/validators_insert.go
+++ b/db/validators_insert.go
@@ -22,6 +22,25 @@ const (
 	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name
 	WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`
+
+	// A custodian pin must not depend on some other phase creating the row:
+	// without this, a pin declared before the validator is tracked is silently
+	// dropped until an unrelated write creates the row (review finding on
+	// PR #43). Creates missing rows with the pipeline default and never
+	// touches existing ones; the dimension pass then applies the pin.
+	ensureCustodianPinRowsQuery = `
+	INSERT INTO t_identified_validators (
+		f_validator_pubkey,
+		f_pool_name
+	)
+	SELECT
+		f_validator_pubkey,
+		'solo_stakers'
+	FROM
+		t_validators_insert
+	WHERE f_dimension = 'custodian'
+	ON CONFLICT (f_validator_pubkey) DO NOTHING;
+	`
 )
 
 func (p *PostgresDBService) ApplyValidatorsInsert() error {
@@ -33,9 +52,14 @@ func (p *PostgresDBService) ApplyValidatorsInsert() error {
 	}
 	defer conn.Release()
 
-	_, err = conn.Query(p.ctx, applyValidatorsInsertQuery)
+	_, err = conn.Exec(p.ctx, applyValidatorsInsertQuery)
 	if err != nil {
 		return errors.Wrap(err, "error applying validators insert")
+	}
+
+	_, err = conn.Exec(p.ctx, ensureCustodianPinRowsQuery)
+	if err != nil {
+		return errors.Wrap(err, "error ensuring custodian pin rows")
 	}
 	return nil
 }

--- a/db/validators_insert.go
+++ b/db/validators_insert.go
@@ -3,9 +3,11 @@ package db
 import "github.com/pkg/errors"
 
 const (
-	// Rows with a declared dimension assert f_operator or f_custodian only
-	// (see migration 000013 and ApplyDimensionColumns); they must not touch
-	// the legacy f_pool_name label.
+	// Legacy pins (f_dimension NULL) and operator pins both write the display
+	// label: entities have always been the operator when known (Lido
+	// validators show their operator, not "lido"). Custodian pins assert
+	// custody only (see migration 000013 and ApplyDimensionColumns) and must
+	// not touch f_pool_name.
 	applyValidatorsInsertQuery = `
 	INSERT INTO t_identified_validators (
 		f_validator_pubkey,
@@ -16,7 +18,7 @@ const (
 		f_pool_name
 	FROM
 		t_validators_insert
-	WHERE f_dimension IS NULL
+	WHERE f_dimension IS DISTINCT FROM 'custodian'
 	ON CONFLICT (f_validator_pubkey) DO UPDATE SET f_pool_name = EXCLUDED.f_pool_name
 	WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;
 	`

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -26,11 +26,11 @@ const (
 				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
 			AND NOT EXISTS (SELECT 1 FROM t_lido l
 				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
-			-- Declared-dimension pins (migration 000013) never write
-			-- f_pool_name, so only legacy pins suppress this phase.
+			-- Custodian pins (migration 000013) never write f_pool_name, so
+			-- only pins that claim the display label suppress this phase.
 			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
 				WHERE vi.f_validator_pubkey = v.f_validator_pubkey
-				AND vi.f_dimension IS NULL)
+				AND vi.f_dimension IS DISTINCT FROM 'custodian')
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;

--- a/db/withdrawal_address_insert.go
+++ b/db/withdrawal_address_insert.go
@@ -26,8 +26,11 @@ const (
 				WHERE r.f_validator_pubkey = v.f_validator_pubkey)
 			AND NOT EXISTS (SELECT 1 FROM t_lido l
 				WHERE l.f_validator_pubkey = v.f_validator_pubkey)
+			-- Declared-dimension pins (migration 000013) never write
+			-- f_pool_name, so only legacy pins suppress this phase.
 			AND NOT EXISTS (SELECT 1 FROM t_validators_insert vi
-				WHERE vi.f_validator_pubkey = v.f_validator_pubkey)
+				WHERE vi.f_validator_pubkey = v.f_validator_pubkey
+				AND vi.f_dimension IS NULL)
 		ON CONFLICT (f_validator_pubkey) DO UPDATE SET
 			f_pool_name = EXCLUDED.f_pool_name
 		WHERE t_identified_validators.f_pool_name IS DISTINCT FROM EXCLUDED.f_pool_name;


### PR DESCRIPTION
## Problem

Phase 1 of the two-dimension model (#42) fills `f_operator` and `f_custodian` from address-level mappings and on-chain registries only. Those sources cannot express pubkey-level operator knowledge: for delegated validators the depositor is the platform or custodian, not whoever runs the machines, so `f_operator` inherits the owner's name and the real operator remains unrepresentable, both in the pure column and as an entity. Concrete case: 3,991 validators operated by Luganodes whose owners are ether.fi (1,902, single EigenPod, verified by 10,901/10,901 blocks with operator graffiti), Bitfinex (1,609, SSV cluster CL1), Renzo and Kelp (SSV clusters CL5/CL3) and 22 retail.

## Change

Phase 2 of issue #28, additive and backward compatible:

- Migration 000013 adds nullable `f_dimension` to `t_validators_insert` with a CHECK on (`NULL`, `'operator'`, `'custodian'`). `NULL` keeps the exact legacy behavior.
- Operator pins write `f_operator`, ranked as the strongest evidence in that dimension, and also claim the display label: entities are the operator when known, the same reason Lido validators show kiln or figment instead of `lido`. Through the labels sync this is what makes the operator appear as an entity downstream.
- Custodian pins write only `f_custodian` and never touch `f_pool_name`.
- The depositor and withdrawal anti-join guards suppress on any display-claiming pin (legacy or operator) but not on custodian pins. Without the distinction, a custodian pin would block the owner mapping and the weekly full rebuild would strand those validators on whale or default labels (caught in design review, covered by the rebuild simulation test).
- One row per pubkey (PK unchanged): a pubkey cannot carry two pins. Widening the PK is future work if a real case needs both dimensions pinned.

## Validation

- Synthetic steady-state and full-rebuild simulations with the production queries: legacy pins unchanged, operator pin sets both `f_operator` and the display label (beating the Lido registry value in both), custodian pin leaves the display untouched, CHECK rejects invalid dimensions, rebuild converges to the same state.
- Deployed to the production labels host end to end: migration 000013 applied cleanly, canary of 3 declared pins verified, then the full 3,991-pin insert; the dimension pass wrote the delta in under 20s inside the normal hourly window.
- Rollout result: `f_operator = 'luganodes'` and entity `luganodes` (3,991) with the expected per-pool moves (ether.fi -1,902, bitfinex -1,609, renzo_protocol -258, whale_0xf02d -200, solo_stakers -22), all far below the labels-sync pool-drop gate (5,000), so both ClickHouse targets pick the entity up through the existing hourly sync unchanged.

## Operational notes

- Rows with `f_dimension IS NULL` behave exactly as before across every touched query; consumers keep reading `f_pool_name` and simply see the new entity.
- The labels sync script needs no changes for the entity to propagate; exporting the pure dimension columns to ClickHouse remains future work under issue #28.

## Rollback

Migration down drops the CHECK and the column. Deleting the pin rows makes the next run recompute both the display label and `f_operator` back from the address-level sources.
